### PR TITLE
Add PuzzleForge Publisher: standalone MS-Publisher-style page editor

### DIFF
--- a/publisher/electron/main.js
+++ b/publisher/electron/main.js
@@ -1,0 +1,133 @@
+'use strict';
+/**
+ * Electron shell for PuzzleForge Publisher — the standalone page editor.
+ *
+ * Boots the trimmed Express app (server.js) in-process and opens it in a
+ * native window, straight to editor.html. There is nowhere else to
+ * navigate to — this app is the page editor only.
+ */
+const { app, BrowserWindow, Menu, shell } = require('electron');
+
+const PORT = Number(process.env.PORT) || 4100;
+const HOST = '127.0.0.1';
+const ORIGIN = `http://${HOST}:${PORT}`;
+
+let mainWindow = null;
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const { app: expressApp } = require('../server');
+    const server = expressApp.listen(PORT, HOST, () => resolve());
+    server.on('error', (err) => {
+      // A dev server (`npm start`) may already be running on this port —
+      // reuse it instead of failing to launch.
+      if (err.code === 'EADDRINUSE') resolve();
+      else reject(err);
+    });
+  });
+}
+
+function isLocalUrl(url) {
+  return url.startsWith(`${ORIGIN}/`);
+}
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1440,
+    height: 900,
+    minWidth: 960,
+    minHeight: 640,
+    title: 'PuzzleForge Publisher',
+    backgroundColor: '#1c1f24',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  mainWindow.loadURL(`${ORIGIN}/editor.html`);
+
+  // Everything the editor links to externally (mailto:, "browse issues") opens
+  // in the OS's default browser instead of a second app window.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (isLocalUrl(url)) return { action: 'allow' };
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!isLocalUrl(url)) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+function buildMenu() {
+  const template = [
+    {
+      label: 'File',
+      submenu: [{ role: 'reload' }, { role: 'forceReload' }, { type: 'separator' }, { role: 'quit' }],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+        { type: 'separator' },
+        { role: 'toggleDevTools' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [{ role: 'minimize' }, { role: 'close' }],
+    },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+
+  app.whenReady().then(async () => {
+    buildMenu();
+    await startServer();
+    createWindow();
+
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+  });
+
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit();
+  });
+}

--- a/publisher/package-lock.json
+++ b/publisher/package-lock.json
@@ -1,0 +1,5226 @@
+{
+  "name": "puzzleforge-publisher",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "puzzleforge-publisher",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.106.0",
+        "archiver": "^7.0.1",
+        "express": "^4.19.2",
+        "puzzleforge-engine": "file:..",
+        "qrcode-generator": "^2.0.4"
+      },
+      "devDependencies": {
+        "electron": "^43.0.0",
+        "electron-builder": "^26.0.0"
+      }
+    },
+    "..": {
+      "name": "puzzleforge-engine",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "bad-words": "^3.0.4",
+        "puppeteer-core": "^22.0.0",
+        "qrcode-generator": "^2.0.4",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "puzzleforge": "cli/index.js",
+        "puzzleforge-mcp": "mcp/server.js"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.106.0.tgz",
+      "integrity": "sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+      "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+      "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.3.1",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-lib": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "3.4.1",
+        "@electron/fuses": "^1.8.0",
+        "@electron/get": "^3.0.0",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.3",
+        "@electron/rebuild": "^4.0.4",
+        "@electron/universal": "2.0.3",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@noble/hashes": "^2.2.0",
+        "@peculiar/webcrypto": "^1.7.1",
+        "@types/fs-extra": "9.0.13",
+        "ajv": "^8.18.0",
+        "asn1js": "^3.0.10",
+        "async-exit-hook": "^2.0.1",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
+        "chromium-pickle-js": "^0.2.0",
+        "ci-info": "4.3.1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "26.15.3",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "isbinaryfile": "^5.0.0",
+        "jiti": "^2.4.2",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.2.5",
+        "pkijs": "^3.4.0",
+        "plist": "3.1.0",
+        "proper-lockfile": "^4.1.2",
+        "resedit": "^1.7.0",
+        "semver": "~7.7.3",
+        "tar": "^7.5.7",
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0",
+        "unzipper": "^0.12.3",
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "26.15.3",
+        "electron-builder-squirrel-windows": "26.15.3"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+      "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/ci-info": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.1.tgz",
+      "integrity": "sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "builder-util-runtime": "9.7.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "js-yaml": "^4.1.0",
+        "sanitize-filename": "^1.6.3",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "43.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
+      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "dmg-builder": "26.15.3",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
+        "electron-winstaller": "5.4.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "aws4": "^1.13.2",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
+        "chalk": "^4.1.2",
+        "form-data": "^4.0.5",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puzzleforge-engine": {
+      "resolved": "..",
+      "link": true
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tiny-async-pool": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+      "integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.5.0"
+      }
+    },
+    "node_modules/tiny-async-pool/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "11.3.1",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    }
+  }
+}

--- a/publisher/package.json
+++ b/publisher/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "puzzleforge-publisher",
+  "version": "0.1.0",
+  "description": "Standalone MS-Publisher-style page editor for PuzzleForge books — Electron desktop app.",
+  "private": true,
+  "license": "MIT",
+  "main": "electron/main.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js",
+    "electron": "electron .",
+    "dist:win": "electron-builder --win"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.106.0",
+    "archiver": "^7.0.1",
+    "express": "^4.19.2",
+    "puzzleforge-engine": "file:..",
+    "qrcode-generator": "^2.0.4"
+  },
+  "devDependencies": {
+    "electron": "^43.0.0",
+    "electron-builder": "^26.0.0"
+  },
+  "build": {
+    "appId": "com.puzzleforge.publisher",
+    "productName": "PuzzleForge Publisher",
+    "files": [
+      "electron/**/*",
+      "server.js",
+      "public/**/*",
+      "node_modules/**/*",
+      "!node_modules/electron-builder/**/*",
+      "!node_modules/puzzleforge-engine/puzzleforge-web/**",
+      "!node_modules/puzzleforge-engine/publisher/**",
+      "!node_modules/puzzleforge-engine/{tests,docs,cli,mcp,scripts,examples,.git}/**",
+      "!node_modules/puzzleforge-engine/{PRD.md,README.md}"
+    ],
+    "win": {
+      "target": "nsis"
+    }
+  }
+}

--- a/publisher/public/editor.html
+++ b/publisher/public/editor.html
@@ -1,0 +1,1560 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PuzzleForge — Page Editor</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="editor-body theme-dark">
+  <header class="ribbon">
+    <!-- Title strip: brand, nav, quick actions -->
+    <div class="ribbon-title">
+      <div class="brand">
+        <span class="logo">▦</span>
+        <div>
+          <h1>PuzzleForge</h1>
+          <p class="tagline">Page Editor</p>
+        </div>
+      </div>
+      <nav class="nav">
+        <a href="editor.html" class="active">Page Editor</a>
+      </nav>
+      <div class="ribbon-qa">
+        <span id="saveState" class="save-state" title="Books autosave to My Books in this browser"></span>
+        <button id="undo" class="iconbtn" title="Undo (Ctrl+Z)">↶</button>
+        <button id="redo" class="iconbtn" title="Redo (Ctrl+Y)">↷</button>
+        <span class="qa-sep"></span>
+        <label class="upload ghost">Open recipe<input id="loadRecipe" type="file" accept="application/json" hidden></label>
+        <button id="save" class="ghost">Save recipe</button>
+        <button id="exportPdf" class="ghost">Export PDF</button>
+        <button id="publishBtn" class="primary">Publish…</button>
+      </div>
+    </div>
+
+    <!-- Tab bar -->
+    <div class="ribbon-tabs" role="tablist">
+      <button class="rtab active" data-tab="home" role="tab">Home</button>
+      <button class="rtab" data-tab="insert" role="tab">Insert</button>
+      <button class="rtab" data-tab="design" role="tab">Page Design</button>
+      <button class="rtab" data-tab="team" role="tab">Team</button>
+      <button class="rtab" data-tab="review" role="tab">Review</button>
+      <button class="rtab" data-tab="view" role="tab">View</button>
+      <button class="rtab" data-tab="help" role="tab">Help</button>
+      <button class="rtab rtab-context" data-tab="shapeformat" id="ctxTab2" role="tab">Shape Format</button>
+      <button class="rtab rtab-context" data-tab="tabledesign" id="ctxTabTD" role="tab">Table Design</button>
+      <button class="rtab rtab-context" data-tab="tablelayout" id="ctxTabTL" role="tab">Table Layout</button>
+      <button class="rtab rtab-context" data-tab="pictureformat" id="ctxTabPic" role="tab">Picture Format</button>
+      <button class="rtab rtab-context" data-tab="qrformat" id="ctxTabQr" role="tab">QR Code</button>
+      <button class="rtab rtab-context" data-tab="format" id="ctxTab" role="tab">Text Box</button>
+    </div>
+
+    <!-- Ribbon body: one panel per tab -->
+    <div class="ribbon-body">
+      <!-- HOME -->
+      <section class="ribbon-panel active" data-panel="home">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="pasteBtn" class="rbig" title="Paste (Ctrl+V)"><span class="rbig-ico">📋</span>Paste</button>
+            <span class="rmini-col">
+              <button id="cutBtn" class="rmini" title="Cut (Ctrl+X)"><span class="rmini-ico">✂</span>Cut</button>
+              <button id="copyBtn" class="rmini" title="Copy (Ctrl+C)"><span class="rmini-ico">⧉</span>Copy</button>
+              <button id="fmtPainter" class="rmini" title="Format Painter — copy this object's look, then click another to apply it"><span class="rmini-ico">🖌</span>Format Painter</button>
+            </span>
+          </div>
+          <div class="rgroup-name">Clipboard</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body font-body">
+            <select id="fontFamily" class="mini js-font-family" title="Font">
+              <option value="sans">Sans</option>
+              <option value="serif">Serif</option>
+              <option value="mono">Mono</option>
+              <option value="hand">Handwritten</option>
+            </select>
+            <input id="fontSize" class="mini-num js-font-size" type="number" min="6" max="200" value="24" title="Font size">
+            <button id="fontGrow" class="iconbtn js-font-grow" title="Grow font">A˄</button>
+            <button id="fontShrink" class="iconbtn js-font-shrink" title="Shrink font">A˅</button>
+            <button id="boldBtn" class="iconbtn tstyle js-bold" title="Bold"><b>B</b></button>
+            <button id="italicBtn" class="iconbtn tstyle js-italic" title="Italic"><i>I</i></button>
+            <button id="underBtn" class="iconbtn tstyle js-underline" title="Underline"><u>U</u></button>
+            <input id="objColor" class="mini-color js-font-color" type="color" value="#222222" title="Text color">
+            <button id="caseBtn" class="iconbtn js-font-case" title="Change case (UPPER / lower / Title)">Aa</button>
+            <button id="clearFmt" class="iconbtn js-font-clear" title="Clear text formatting">⌫</button>
+          </div>
+          <div class="rgroup-name">Font</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body para-body">
+            <button class="iconbtn palign" data-align="left" title="Align left">⯇</button>
+            <button class="iconbtn palign" data-align="center" title="Center">≡</button>
+            <button class="iconbtn palign" data-align="right" title="Align right">⯈</button>
+            <select id="lineSpacing" class="mini js-line-spacing" title="Line spacing">
+              <option value="1">1.0</option>
+              <option value="1.15">1.15</option>
+              <option value="1.25" selected>1.25</option>
+              <option value="1.5">1.5</option>
+              <option value="2">2.0</option>
+            </select>
+          </div>
+          <div class="rgroup-name">Paragraph</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body objects-body">
+            <button id="hAddText" class="rbig" title="Draw a text box"><span class="rbig-ico">🄰</span>Text</button>
+            <label class="upload rbig" title="Insert a picture from your device"><span class="rbig-ico">🖼</span>Pictures<input id="hAddImage" type="file" accept="image/*" hidden></label>
+            <span class="rdrop" id="tableDrop">
+              <button class="rbig rdrop-btn" id="tableDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a table"><span class="rbig-ico">▦</span>Table&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu tablepick-menu" hidden>
+                <div class="tablepick-grid" id="tablepickGrid"></div>
+                <div class="tablepick-label" id="tablepickLabel">Insert Table</div>
+                <button type="button" class="tablepick-more" id="tablepickMore">Insert Table…</button>
+              </div>
+            </span>
+            <span class="rdrop" id="shapeDrop">
+              <button class="rbig rdrop-btn" id="shapeDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a shape"><span class="rbig-ico">⬠</span>Shapes&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu shapegal-menu" id="shapeGallery" hidden></div>
+            </span>
+          </div>
+          <div class="rgroup-name">Objects</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="wrapDrop">
+              <button class="rbig rdrop-btn" id="wrapDropBtn" aria-haspopup="true" aria-expanded="false" title="How this object layers with the puzzle & text"><span class="rbig-ico">◲</span>Wrap&nbsp;Text&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="wfront">▤ In Front of Puzzle</button>
+                <button type="button" data-act="wbehind">▥ Behind Puzzle</button>
+              </div>
+            </span>
+            <span class="rmini-grid">
+              <button id="hForward" class="rmini" title="Bring forward"><span class="rmini-ico">⭱</span>Bring Forward</button>
+              <button id="hBackward" class="rmini" title="Send back"><span class="rmini-ico">⭳</span>Send Backward</button>
+              <span class="rdrop" id="alignDrop">
+                <button class="rmini rdrop-btn" id="alignDropBtn" aria-haspopup="true" aria-expanded="false" title="Align or distribute the selection"><span class="rmini-ico">⯐</span>Align&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="aleft">⯇ Align Left</button>
+                  <button type="button" data-act="acenter">≡ Align Center</button>
+                  <button type="button" data-act="aright">⯈ Align Right</button>
+                  <button type="button" data-act="atop">⤒ Align Top</button>
+                  <button type="button" data-act="amiddle">⇕ Align Middle</button>
+                  <button type="button" data-act="abottom">⤓ Align Bottom</button>
+                  <button type="button" data-act="disth">⇿ Distribute Horizontally</button>
+                  <button type="button" data-act="distv">⇳ Distribute Vertically</button>
+                </div>
+              </span>
+              <button id="hGroup" class="rmini" title="Group"><span class="rmini-ico">⊞</span>Group</button>
+              <button id="hUngroup" class="rmini" title="Ungroup"><span class="rmini-ico">⊟</span>Ungroup</button>
+              <span class="rdrop" id="rotateDrop">
+                <button class="rmini rdrop-btn" id="rotateDropBtn" aria-haspopup="true" aria-expanded="false" title="Rotate or flip the selection"><span class="rmini-ico">⟳</span>Rotate&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="rright">⟳ Rotate Right 90°</button>
+                  <button type="button" data-act="rleft">⟲ Rotate Left 90°</button>
+                  <button type="button" data-act="flipv">⇅ Flip Vertical</button>
+                  <button type="button" data-act="fliph">⇆ Flip Horizontal</button>
+                  <button type="button" data-act="free">⌖ Free Rotate…</button>
+                </div>
+              </span>
+            </span>
+          </div>
+          <div class="rgroup-name">Arrange</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rmini-col">
+              <button id="findReplaceBtn" class="rmini" title="Find &amp; Replace (Ctrl+F)"><span class="rmini-ico">🔍</span>Find &amp; Replace</button>
+              <button id="selectAllBtn" class="rmini" title="Select all (Ctrl+A)"><span class="rmini-ico">▣</span>Select All</button>
+            </span>
+          </div>
+          <div class="rgroup-name">Editing</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="breakApartBtn" class="rbig" title="Turn the puzzle's title & word list into editable text objects (the grid stays protected)"><span class="rbig-ico">✂</span>Break&nbsp;Apart</button>
+          </div>
+          <div class="rgroup-name">Puzzle</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rmini-grid">
+              <button id="dupObj" class="rmini" title="Duplicate (Ctrl+D)"><span class="rmini-ico">⧉</span>Duplicate</button>
+              <button id="deleteObj" class="rmini del" title="Delete"><span class="rmini-ico">🗑</span>Delete</button>
+              <button id="lockObj" class="rmini" title="Lock / unlock"><span class="rmini-ico">🔒</span>Lock</button>
+              <button id="reroll" class="rmini" title="Reroll this puzzle"><span class="rmini-ico">🎲</span>Reroll</button>
+              <button id="resetLayout" class="rmini" title="Reset the page layout"><span class="rmini-ico">⟲</span>Reset</button>
+            </span>
+          </div>
+          <div class="rgroup-name">Page</div>
+        </div>
+      </section>
+
+      <!-- INSERT (grouped like Publisher: Pages · Tables · Illustrations ·
+           Building Blocks · Text · Header & Footer) -->
+      <section class="ribbon-panel" data-panel="insert">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="pageDrop">
+              <button class="rbig rdrop-btn" id="pageDropBtn" aria-haspopup="true" aria-expanded="false"><span class="rbig-ico">📄</span>Page&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="puzzle">🧩 Insert Puzzle…</button>
+                <button type="button" data-act="blank">📄 Insert Blank Page</button>
+                <button type="button" data-act="dup">⧉ Insert Duplicate Page</button>
+                <button type="button" data-act="tpl">🗂 Insert Page…</button>
+              </div>
+            </span>
+            <button id="savePageTpl" class="rbig" title="Save this page's layout as a reusable template"><span class="rbig-ico">🗂</span>Save as<br>Template</button>
+          </div>
+          <div class="rgroup-name">Pages</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="insTableDrop">
+              <button class="rbig rdrop-btn" id="insTableDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a table"><span class="rbig-ico">▦</span>Table&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu tablepick-menu" hidden>
+                <div class="tablepick-grid" id="insTablepickGrid"></div>
+                <div class="tablepick-label" id="insTablepickLabel">Insert Table</div>
+                <button type="button" class="tablepick-more" id="insTablepickMore">Insert Table…</button>
+              </div>
+            </span>
+            <button id="addQr" class="rbig" title="Insert a QR code linking to a URL"><span class="rbig-ico">▣</span>QR<br>Code</button>
+          </div>
+          <div class="rgroup-name">Tables</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <label class="upload rbig" title="Insert a picture from your device"><span class="rbig-ico">🖼</span>Picture<input id="addImage" type="file" accept="image/*" hidden></label>
+            <button id="addPicPlaceholder" class="rbig" title="Insert an empty picture frame — double-click it later to fill it"><span class="rbig-ico">▢</span>Picture<br>Placeholder</button>
+            <span class="rdrop" id="insShapeDrop">
+              <button class="rbig rdrop-btn" id="insShapeDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a shape"><span class="rbig-ico">⬠</span>Shapes&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu shapegal-menu" id="insShapeGallery" hidden></div>
+            </span>
+          </div>
+          <div class="rgroup-name">Illustrations</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="pagePartsDrop">
+              <button class="rbig rdrop-btn" id="pagePartsDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a pre-designed heading, pull quote, or sidebar"><span class="rbig-ico">▤</span>Page&nbsp;Parts&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu shapegal-menu" id="pagePartsMenu" hidden></div>
+            </span>
+            <button id="addCalendarBtn" class="rbig" title="Insert a month calendar"><span class="rbig-ico">📅</span>Calendars</button>
+            <span class="rdrop" id="accentDrop">
+              <button class="rbig rdrop-btn" id="accentDropBtn" aria-haspopup="true" aria-expanded="false" title="Insert a decorative accent bar"><span class="rbig-ico">▬</span>Borders&nbsp;&amp;<br>Accents&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="line">— Thin line</button>
+                <button type="button" data-act="bar">▬ Slim bar</button>
+                <button type="button" data-act="thick">▮ Thick bar</button>
+                <button type="button" data-act="double">═ Double line</button>
+              </div>
+            </span>
+            <label class="field compact bb-border"><span>Page border</span>
+              <select id="border"><option value="">(book default)</option></select>
+            </label>
+            <button id="borderAll" class="ghost" title="Use this border on every page">Apply to all</button>
+          </div>
+          <div class="rgroup-name">Building Blocks</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="addText" class="rbig"><span class="rbig-ico">🄰</span>Text<br>Box</button>
+            <span class="rmini-col">
+              <select id="wordArt" class="mini" title="WordArt — styled title">
+                <option value="" disabled selected>WordArt…</option>
+              </select>
+              <select id="symbolPick" class="mini" title="Insert symbol">
+                <option value="" disabled selected>Ω Symbol…</option>
+              </select>
+            </span>
+            <button id="insertDate" class="rbig" title="Insert today's date"><span class="rbig-ico">📆</span>Date</button>
+          </div>
+          <div class="rgroup-name">Text</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="insLinkBtn" class="rbig" title="Make the selected object a clickable link (digital PDF)"><span class="rbig-ico">🔗</span>Link</button>
+            <button id="insBookmarkBtn" class="rbig" title="Tag the selected object with a bookmark name"><span class="rbig-ico">🔖</span>Bookmark</button>
+          </div>
+          <div class="rgroup-name">Links</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="insHeader" class="rbig" title="Add a repeating header (edits the master page)"><span class="rbig-ico">▔</span>Header</button>
+            <button id="insFooter" class="rbig" title="Add a repeating footer (edits the master page)"><span class="rbig-ico">▁</span>Footer</button>
+            <span class="rdrop" id="pageNoDrop">
+              <button class="rbig rdrop-btn" id="pageNoDropBtn" aria-haspopup="true" aria-expanded="false"><span class="rbig-ico">#</span>Page&nbsp;<br>Number&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="tl">↖ Top Left</button>
+                <button type="button" data-act="tc">▲ Top Center</button>
+                <button type="button" data-act="tr">↗ Top Right</button>
+                <button type="button" data-act="bl">↙ Bottom Left</button>
+                <button type="button" data-act="bc">▼ Bottom Center</button>
+                <button type="button" data-act="br">↘ Bottom Right</button>
+              </div>
+            </span>
+          </div>
+          <div class="rgroup-name">Header &amp; Footer</div>
+        </div>
+      </section>
+
+      <!-- PAGE DESIGN (Publisher-style: one row of icon-over-label buttons) -->
+      <section class="ribbon-panel" data-panel="design">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="changeTplBtn" class="rbig" title="Apply a page template — replaces this page's layout"><span class="rbig-ico">🗂</span>Change<br>Template</button>
+          </div>
+          <div class="rgroup-name">Template</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="marginsDrop">
+              <button class="rbig rdrop-btn" id="marginsDropBtn" aria-haspopup="true" aria-expanded="false" title="Margin guide preset"><span class="rbig-ico">▭</span>Margins&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="wide">Wide — 1″</button>
+                <button type="button" data-act="moderate">Moderate — 0.5″</button>
+                <button type="button" data-act="narrow">Narrow — 0.25″</button>
+                <button type="button" data-act="none">None — 0″</button>
+                <button type="button" data-act="custom">Custom margin…</button>
+                <div class="rdrop-sep"></div>
+                <button type="button" data-act="fit">⤢ Fit page to margins</button>
+                <div class="rdrop-sep"></div>
+                <label class="rdrop-check"><input type="checkbox" id="marginGuide"> Show safe-margin guide</label>
+              </div>
+            </span>
+            <span class="rdrop" id="orientDrop">
+              <button class="rbig rdrop-btn" id="orientDropBtn" aria-haspopup="true" aria-expanded="false" title="Page orientation"><span class="rbig-ico">▯</span>Orientation&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <div class="rdrop-note">Orientation: <b id="orientInfo">—</b></div>
+                <div class="rdrop-hint">Trim orientation is set per book in the Book Builder.</div>
+              </div>
+            </span>
+            <span class="rdrop" id="sizeDrop">
+              <button class="rbig rdrop-btn" id="sizeDropBtn" aria-haspopup="true" aria-expanded="false" title="Trim size"><span class="rbig-ico">▤</span>Size&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <div class="rdrop-note">Trim: <b id="sizeInfo">—</b></div>
+                <div class="rdrop-hint">KDP prints one trim per book — change it in the Book Builder.</div>
+              </div>
+            </span>
+          </div>
+          <div class="rgroup-name">Page Setup</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="guidesDrop">
+              <button class="rbig rdrop-btn" id="guidesDropBtn" aria-haspopup="true" aria-expanded="false" title="Ruler guides"><span class="rbig-ico">⌗</span>Guides&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu" hidden>
+                <button type="button" data-act="addh">➕ Add horizontal guide</button>
+                <button type="button" data-act="addv">➕ Add vertical guide</button>
+                <button type="button" data-act="clear">🗑 Clear guides</button>
+              </div>
+            </span>
+            <span class="rmini-col align-to">
+              <span class="design-info">Align To</span>
+              <label class="checkbox"><input type="checkbox" id="alignGuidesChk" checked> Guides</label>
+              <label class="checkbox"><input type="checkbox" id="alignObjectsChk" checked> Objects</label>
+            </span>
+          </div>
+          <div class="rgroup-name">Layout</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rmini-col">
+              <button id="delPage" class="rmini del" title="Delete this page"><span class="rmini-ico">🗑</span>Delete</button>
+              <button id="renamePage" class="rmini" title="Give this page a name in the page list"><span class="rmini-ico">✎</span>Rename</button>
+              <button id="movePageUp" class="rmini" title="Move page up"><span class="rmini-ico">↑</span>Move Up</button>
+              <button id="movePageDown" class="rmini" title="Move page down"><span class="rmini-ico">↓</span>Move Down</button>
+            </span>
+          </div>
+          <div class="rgroup-name">Pages</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <div class="scheme-gallery" id="schemeGallery"></div>
+          </div>
+          <div class="rgroup-name">Schemes</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="fontsDrop">
+              <button class="rbig rdrop-btn" id="fontsDropBtn" aria-haspopup="true" aria-expanded="false" title="Set the font for all text on this page"><span class="rbig-ico rbig-aa">Aa</span>Fonts&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu fonts-menu" hidden>
+                <div class="fonts-list" id="fontsList"></div>
+                <div class="rdrop-sep"></div>
+                <label class="fonts-upload" title="Upload a font file (.ttf, .otf, .woff, .woff2)">⬆ Upload font…<input id="fontUpload" type="file" accept=".ttf,.otf,.woff,.woff2,font/*" hidden></label>
+              </div>
+            </span>
+          </div>
+          <div class="rgroup-name">Fonts</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="rdrop" id="bgDrop">
+              <button class="rbig rdrop-btn" id="bgDropBtn" aria-haspopup="true" aria-expanded="false" title="Page background"><span class="rbig-ico">▧</span>Background&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu bg-menu" hidden>
+                <button type="button" class="bg-type" data-bg="none">None (white)</button>
+                <button type="button" class="bg-type" data-bg="solid">Solid color</button>
+                <button type="button" class="bg-type" data-bg="gradient">Gradient</button>
+                <div class="rdrop-sep"></div>
+                <div class="bg-colors" id="bgColors" style="display:none;">
+                  <label class="rdrop-field"><span>Color</span><input id="bgColor" type="color" class="mini-color" value="#ffffff"></label>
+                  <label class="rdrop-field" id="bgColor2Field"><span>Color 2</span><input id="bgColor2" type="color" class="mini-color" value="#dddddd"></label>
+                  <label class="rdrop-field" id="bgAngleField"><span>Angle°</span><input id="bgAngle" class="mini-num" type="number" min="0" max="360" value="180"></label>
+                </div>
+              </div>
+            </span>
+            <span class="rdrop" id="masterDrop">
+              <button class="rbig rdrop-btn" id="masterDropBtn" aria-haspopup="true" aria-expanded="false" title="Master page (page numbers, headers, frames)"><span class="rbig-ico">📄</span>Master&nbsp;<span class="rdrop-caret">▾</span></button>
+              <div class="rdrop-menu master-menu" hidden>
+                <label class="rdrop-check"><input type="checkbox" id="masterEnabled" checked> Show master on pages</label>
+                <button type="button" id="editMasterBtn" class="rdrop-item" title="Edit the master overlay">✎ Edit Master Page</button>
+                <button type="button" id="insertPageNo" class="rdrop-item" title="Add an auto page-number field to the master"># Page Number field</button>
+                <div class="rdrop-sep"></div>
+                <label class="rdrop-field"><span>Applies to</span>
+                  <select id="masterApplyTo"><option value="all">All pages</option><option value="odd">Odd only</option><option value="even">Even only</option></select></label>
+                <label class="rdrop-field"><span>Skip first</span><input id="masterSkip" type="number" min="0" max="20" value="1" title="Pages at the start with no master"></label>
+                <label class="rdrop-field"><span>Start at</span><input id="masterStart" type="number" min="0" max="9999" value="1"></label>
+              </div>
+            </span>
+          </div>
+          <div class="rgroup-name">Page Background</div>
+        </div>
+      </section>
+
+      <!-- ARRANGE -->
+      <!-- TEAM (workspace, collaboration & handoffs) -->
+      <section class="ribbon-panel" data-panel="team">
+        <div class="rgroup">
+          <div class="rgroup-body col">
+            <button id="shareTeamBtn" class="primary" title="Publish this book to your team workspace so everyone on the LAN can open it">☁ Share to team</button>
+            <button id="saveMineBtn" class="ghost" title="Save a personal copy of this team book to My Books" style="display:none;">📥 Save to my library</button>
+            <span id="wsStatus" class="design-info">—</span>
+          </div>
+          <div class="rgroup-name">Workspace</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="teamBtn" class="ghost" title="Manage your team roster">👥 Team Roster</button>
+            <button id="inviteBtn" class="ghost" title="Invite someone to the team">＋ Invite</button>
+          </div>
+          <div class="rgroup-name">Team</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body col">
+            <select id="mailRecipient" class="mini" title="Who share actions target"><option value="">— pick a team member —</option></select>
+          </div>
+          <div class="rgroup-name">Recipient</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="emailBookBtn" class="ghost" title="Email this book to the selected member">📧 Email Book</button>
+            <button id="linkBtn" class="ghost" title="Copy a personalized link for the selected member">🔗 Personalized Link</button>
+          </div>
+          <div class="rgroup-name">Share</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body col">
+            <select id="mailStage" class="mini" title="Workflow stage of this book">
+              <option value="Draft">Draft</option>
+              <option value="Writing">Writing</option>
+              <option value="Editing">Editing</option>
+              <option value="Review">Review</option>
+              <option value="Final">Final</option>
+            </select>
+            <button id="assignBtn" class="ghost" title="Assign this book to the selected member">👤 Assign to recipient</button>
+          </div>
+          <div class="rgroup-name">Workflow</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="notesBtn" class="ghost" title="Handoff notes for this book">📝 Handoff Notes</button>
+          </div>
+          <div class="rgroup-name">Notes</div>
+        </div>
+      </section>
+
+      <!-- REVIEW -->
+      <section class="ribbon-panel" data-panel="review">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="revSpelling" class="ghost" title="Check spelling &amp; grammar across the whole book">🔤 Spelling</button>
+            <button id="revThesaurus" class="ghost" title="Synonyms for the selected text box">📖 Thesaurus</button>
+            <button id="revWordCount" class="ghost" title="Word &amp; character counts">🔢 Word Count</button>
+          </div>
+          <div class="rgroup-name">Proofing</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body col">
+            <select id="revLanguage" class="mini" title="Book language (KDP metadata)">
+              <option value="en">English</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="de">German</option>
+              <option value="it">Italian</option>
+              <option value="pt">Portuguese</option>
+              <option value="nl">Dutch</option>
+              <option value="ja">Japanese</option>
+            </select>
+          </div>
+          <div class="rgroup-name">Language</div>
+        </div>
+      </section>
+
+      <!-- FORMAT (contextual) -->
+      <section class="ribbon-panel" data-panel="format">
+        <div id="selNone" class="rhint">Select an object on the page to format it. Shift-click to select multiple.</div>
+        <div id="selControls" class="ribbon-inline hidden">
+          <!-- Text Box tools — dense Publisher layout (rows packed within groups) -->
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <span class="rdrop" id="tbFitDrop">
+                <button class="rbig rdrop-btn" id="tbFitDropBtn" aria-haspopup="true" aria-expanded="false" title="How the box and text size to each other"><span class="rbig-ico">â</span>Text&nbsp;Fit&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="best">Best Fit</button>
+                  <button type="button" data-act="shrink">Shrink Text on Overflow</button>
+                  <button type="button" data-act="grow">Grow Text Box to Fit</button>
+                  <button type="button" data-act="none">✓ Do Not Autofit</button>
+                </div>
+              </span>
+              <span class="rdrop" id="tbDirDrop">
+                <button class="rbig rdrop-btn" id="tbDirDropBtn" aria-haspopup="true" aria-expanded="false" title="Text direction"><span class="rbig-ico">⇅</span>Text&nbsp;<br>Direction&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="d0">→ Horizontal</button>
+                  <button type="button" data-act="d90">↓ Rotate 90°</button>
+                  <button type="button" data-act="d270">↑ Rotate 270°</button>
+                </div>
+              </span>
+              <button id="tbHyphenBtn" class="rbig" title="Automatically hyphenate long words"><span class="rbig-ico">a-<br>bc</span>Hyphen-<br>ation</button>
+            </div>
+            <div class="rgroup-name">Text</div>
+          </div>
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <div class="font-2row">
+                <div class="frow">
+                  <select class="mini js-font-family" title="Font">
+                    <option value="sans">Sans</option><option value="serif">Serif</option><option value="mono">Mono</option><option value="hand">Handwritten</option>
+                  </select>
+                  <input class="mini-num js-font-size" type="number" min="6" max="200" value="24" title="Font size">
+                  <button class="iconbtn js-font-grow" title="Grow font">A˄</button>
+                  <button class="iconbtn js-font-shrink" title="Shrink font">A˅</button>
+                  <button class="iconbtn js-font-clear" title="Clear text formatting">⌫</button>
+                </div>
+                <div class="frow">
+                  <button class="iconbtn tstyle js-bold" title="Bold"><b>B</b></button>
+                  <button class="iconbtn tstyle js-italic" title="Italic"><i>I</i></button>
+                  <button class="iconbtn tstyle js-underline" title="Underline"><u>U</u></button>
+                  <button class="iconbtn js-font-case" title="Change case (UPPER / lower / Title)">Aa</button>
+                  <input class="mini-color js-font-color" type="color" value="#222222" title="Font colour">
+                </div>
+              </div>
+            </div>
+            <div class="rgroup-name">Font</div>
+          </div>
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <span class="align-grid2">
+                <button class="iconbtn palign" data-align="left" title="Align left">⯇</button>
+                <button class="iconbtn palign" data-align="center" title="Center">≡</button>
+                <button class="iconbtn palign" data-align="right" title="Align right">⯈</button>
+                <button class="iconbtn palign" data-align="justify" title="Justify">▤</button>
+                <select class="mini js-line-spacing" title="Line spacing">
+                  <option value="1">1.0</option><option value="1.15">1.15</option><option value="1.25" selected>1.25</option><option value="1.5">1.5</option><option value="2">2.0</option>
+                </select>
+              </span>
+              <span class="rmini-col">
+                <span class="rdrop" id="tbColsDrop">
+                  <button class="rmini rdrop-btn" id="tbColsDropBtn" aria-haspopup="true" aria-expanded="false" title="Text columns"><span class="rmini-ico">▥</span>Columns&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="1">▮ One Column</button>
+                    <button type="button" data-act="2">▮▮ Two Columns</button>
+                    <button type="button" data-act="3">▮▮▮ Three Columns</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="tbMarginsDrop">
+                  <button class="rmini rdrop-btn" id="tbMarginsDropBtn" aria-haspopup="true" aria-expanded="false" title="Text box inset margins"><span class="rmini-ico">▤</span>Margins&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="none">None — 0″</button>
+                    <button type="button" data-act="narrow">Narrow — 0.04″</button>
+                    <button type="button" data-act="moderate">Moderate — 0.06″</button>
+                    <button type="button" data-act="wide">Wide — 0.1″</button>
+                    <button type="button" data-act="custom">Custom margins…</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Alignment</div>
+          </div>
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <div class="wordart-gallery" id="wordartGallery"></div>
+              <span class="rmini-col">
+                <span class="rdrop" id="tbFillDrop">
+                  <button class="rmini rdrop-btn" id="tbFillDropBtn" aria-haspopup="true" aria-expanded="false" title="Text fill colour"><span class="rmini-ico">🄰</span>Text&nbsp;Fill&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="tbFillMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="tbOutlineDrop">
+                  <button class="rmini rdrop-btn" id="tbOutlineDropBtn" aria-haspopup="true" aria-expanded="false" title="Text outline"><span class="rmini-ico">🅰</span>Text&nbsp;Outline&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="tbOutlineMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="tbEffectsDrop">
+                  <button class="rmini rdrop-btn" id="tbEffectsDropBtn" aria-haspopup="true" aria-expanded="false" title="Text effects"><span class="rmini-ico">✦</span>Text&nbsp;Effects&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="shadow">◍ Toggle shadow</button>
+                    <button type="button" data-act="none">✕ Clear effects</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">WordArt Styles</div>
+          </div>
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <span class="rdrop" id="tbDropCapDrop">
+                  <button class="rmini rdrop-btn" id="tbDropCapDropBtn" aria-haspopup="true" aria-expanded="false" title="Drop cap"><span class="rmini-ico">🅰</span>Drop&nbsp;Cap&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="0">None</button>
+                    <button type="button" data-act="2">Dropped — 2 lines</button>
+                    <button type="button" data-act="3">Dropped — 3 lines</button>
+                    <button type="button" data-act="4">Dropped — 4 lines</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="tbNumDrop">
+                  <button class="rmini rdrop-btn" id="tbNumDropBtn" aria-haspopup="true" aria-expanded="false" title="Number style"><span class="rmini-ico">123</span>Number&nbsp;Style&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="default">Default</button>
+                    <button type="button" data-act="linprop">Proportional Lining</button>
+                    <button type="button" data-act="lintab">Tabular Lining</button>
+                    <button type="button" data-act="oldprop">Proportional Old-style</button>
+                    <button type="button" data-act="oldtab">Tabular Old-style</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="tbLigDrop">
+                  <button class="rmini rdrop-btn" id="tbLigDropBtn" aria-haspopup="true" aria-expanded="false" title="Ligatures"><span class="rmini-ico">fi</span>Ligatures&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="standard">Standard Only</button>
+                    <button type="button" data-act="disc">Standard &amp; Discretionary</button>
+                    <button type="button" data-act="none">No Ligatures</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="tbStyDrop">
+                  <button class="rmini rdrop-btn" id="tbStyDropBtn" aria-haspopup="true" aria-expanded="false" title="Stylistic sets, swash & alternates (for fonts that provide them)"><span class="rmini-ico">𝒮</span>Stylistic&nbsp;Sets&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="ss0">Default (No Set)</button>
+                    <button type="button" data-act="ss1">Stylistic Set 1</button>
+                    <button type="button" data-act="ss2">Stylistic Set 2</button>
+                    <button type="button" data-act="ss3">Stylistic Set 3</button>
+                    <button type="button" data-act="ss4">Stylistic Set 4</button>
+                    <button type="button" data-act="ss5">Stylistic Set 5</button>
+                    <button type="button" data-act="ss6">Stylistic Set 6</button>
+                    <button type="button" data-act="ss7">Stylistic Set 7</button>
+                    <div class="rdrop-sep"></div>
+                    <button type="button" data-act="swash">◠ Swash</button>
+                    <button type="button" data-act="salt">◈ Stylistic Alternates</button>
+                    <button type="button" data-act="calt">⁀ Contextual Alternates</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Typography</div>
+          </div>
+          <div class="rgroup tb-group">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <button id="tbLinkCreate" class="rmini" title="Flow this box's overflow into another text box"><span class="rmini-ico">🔗</span>Create Link</button>
+                <button id="tbLinkBreak" class="rmini" title="Break the link after this box"><span class="rmini-ico">✂</span>Break Link</button>
+              </span>
+              <span class="rmini-col">
+                <button id="tbLinkPrev" class="rmini" title="Select the previous box in the chain"><span class="rmini-ico">⭰</span>Previous</button>
+                <button id="tbLinkNext" class="rmini" title="Select the next box in the chain"><span class="rmini-ico">⭲</span>Next</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Linking</div>
+          </div>
+          <div class="rgroup gen-group" id="measurePanel">
+            <div class="rgroup-body">
+              <span class="rdrop" id="fmtPosDrop">
+                <button class="rmini rdrop-btn" id="fmtPosDropBtn" aria-haspopup="true" aria-expanded="false" title="Position &amp; size"><span class="rmini-ico">⤢</span>Position&nbsp;&amp;<br>Size&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <label class="rdrop-field"><span>X</span><input id="mX" type="number"></label>
+                  <label class="rdrop-field"><span>Y</span><input id="mY" type="number"></label>
+                  <label class="rdrop-field" id="mWField"><span>Width</span><input id="mW" type="number" min="8"></label>
+                  <label class="rdrop-field" id="mHField"><span>Height</span><input id="mH" type="number" min="4"></label>
+                  <label class="rdrop-field"><span>Size %</span><input id="mScale" type="number" min="15" max="800"></label>
+                  <label class="rdrop-field"><span>Angle°</span><input id="mRot" type="number" min="-180" max="180"></label>
+                </div>
+              </span>
+            </div>
+            <div class="rgroup-name">Size</div>
+          </div>
+          <div class="rgroup shp-group" id="shapeProps">
+            <div class="rgroup-body">
+              <span class="rdrop" id="shapeFillDrop">
+                <button class="rmini rdrop-btn" id="shapeFillDropBtn" aria-haspopup="true" aria-expanded="false" title="Shape fill &amp; outline"><span class="rmini-ico">🎨</span>Shape&nbsp;<br>Styles&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <label class="rdrop-field"><span>Fill</span><input id="fillColor" type="color" value="#ffd43b"></label>
+                  <label class="rdrop-check"><input type="checkbox" id="noFill"> No fill</label>
+                  <div class="rdrop-sep"></div>
+                  <label class="rdrop-field"><span>Outline</span><input id="strokeColor" type="color" value="#222222"></label>
+                  <label class="rdrop-field"><span>Line px</span><input id="strokeW" type="number" min="0" max="40" value="2"></label>
+                </div>
+              </span>
+            </div>
+            <div class="rgroup-name">Shape Styles</div>
+          </div>
+          <div class="rgroup" id="tableProps">
+            <div class="rgroup-body">
+              <button id="tblAddRow" class="ghost mini" title="Add a row">＋Row</button>
+              <button id="tblDelRow" class="ghost mini" title="Remove the last row">−Row</button>
+              <button id="tblAddCol" class="ghost mini" title="Add a column">＋Col</button>
+              <button id="tblDelCol" class="ghost mini" title="Remove the last column">−Col</button>
+              <label class="m"><span>Border</span><input id="tblBorder" type="color" value="#333333"></label>
+              <label class="m"><span>Header bg</span><input id="tblHeaderFill" type="color" value="#f0f0f0"></label>
+              <label class="m"><span>&nbsp;</span>
+                <label class="checkbox"><input type="checkbox" id="tblHeader"> Header row</label>
+              </label>
+            </div>
+            <div class="rgroup-name">Table</div>
+          </div>
+          <div class="rgroup gen-group">
+            <div class="rgroup-body">
+              <div class="align-grid">
+                <button class="iconbtn" data-align="left" title="Align left">⇤</button>
+                <button class="iconbtn" data-align="centerh" title="Center across">⇆</button>
+                <button class="iconbtn" data-align="right" title="Align right">⇥</button>
+                <button class="iconbtn" data-align="top" title="Align top">⤒</button>
+                <button class="iconbtn" data-align="middle" title="Align middle">⇅</button>
+                <button class="iconbtn" data-align="bottom" title="Align bottom">⤓</button>
+              </div>
+              <span class="rdrop" id="fmtArrangeDrop">
+                <button class="rmini rdrop-btn" id="fmtArrangeDropBtn" aria-haspopup="true" aria-expanded="false" title="Order, rotate, flip &amp; distribute"><span class="rmini-ico">⯐</span>Order&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="ofront">⤒ Bring to Front</button>
+                  <button type="button" data-act="oforward">↑ Bring Forward</button>
+                  <button type="button" data-act="obackward">↓ Send Backward</button>
+                  <button type="button" data-act="oback">⤓ Send to Back</button>
+                  <div class="rdrop-sep"></div>
+                  <button type="button" data-act="rright">⟳ Rotate Right 90°</button>
+                  <button type="button" data-act="rleft">⟲ Rotate Left 90°</button>
+                  <button type="button" data-act="fliph">⇆ Flip Horizontal</button>
+                  <button type="button" data-act="flipv">⇅ Flip Vertical</button>
+                  <div class="rdrop-sep"></div>
+                  <button type="button" data-act="disth">⇿ Distribute Horizontally</button>
+                  <button type="button" data-act="distv">⇳ Distribute Vertically</button>
+                </div>
+              </span>
+            </div>
+            <div class="rgroup-name">Arrange</div>
+          </div>
+          <div class="rgroup gen-group">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <button id="groupBtn" class="rmini" title="Group (Ctrl+G)"><span class="rmini-ico">⧈</span>Group</button>
+                <button id="ungroupBtn" class="rmini" title="Ungroup (Ctrl+Shift+G)"><span class="rmini-ico">⧉</span>Ungroup</button>
+                <button id="resetPos" class="rmini" title="Reset size"><span class="rmini-ico">⟲</span>Reset Size</button>
+                <button id="hideObj" class="rmini" title="Hide piece"><span class="rmini-ico">🚫</span>Hide</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Object</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SHAPE FORMAT (contextual 2nd tab: text-box frame & shapes) -->
+      <section class="ribbon-panel" data-panel="shapeformat">
+        <div id="sfNone" class="rhint">Select a shape or text box to format its frame.</div>
+        <div id="sfControls" class="ribbon-inline hidden">
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <div class="wordart-gallery" id="sfShapeGallery"></div>
+              <span class="rmini-col">
+                <span class="rdrop" id="sfChangeDrop">
+                  <button class="rmini rdrop-btn" id="sfChangeDropBtn" aria-haspopup="true" aria-expanded="false" title="Change the shape"><span class="rmini-ico">⬟</span>Change&nbsp;Shape&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu shapegal-menu" id="sfChangeMenu" hidden></div>
+                </span>
+                <button id="sfEditText" class="rmini" title="Edit the text inside this box"><span class="rmini-ico">🄰</span>Edit Text</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Insert Shapes</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <div class="wordart-gallery" id="sfStyleGallery"></div>
+              <span class="rmini-col">
+                <span class="rdrop" id="sfFillDrop">
+                  <button class="rmini rdrop-btn" id="sfFillDropBtn" aria-haspopup="true" aria-expanded="false" title="Shape fill"><span class="rmini-ico">🎨</span>Shape&nbsp;Fill&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="sfFillMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="sfOutlineDrop">
+                  <button class="rmini rdrop-btn" id="sfOutlineDropBtn" aria-haspopup="true" aria-expanded="false" title="Shape outline"><span class="rmini-ico">▭</span>Shape&nbsp;Outline&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="sfOutlineMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="sfEffectsDrop">
+                  <button class="rmini rdrop-btn" id="sfEffectsDropBtn" aria-haspopup="true" aria-expanded="false" title="Shape effects"><span class="rmini-ico">✦</span>Shape&nbsp;Effects&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="shadow">◍ Toggle shadow</button>
+                    <button type="button" data-act="none">✕ Clear effects</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Shape Styles</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rdrop" id="sfWrapDrop">
+                <button class="rbig rdrop-btn" id="sfWrapDropBtn" aria-haspopup="true" aria-expanded="false" title="How this object layers with the puzzle"><span class="rbig-ico">◲</span>Wrap&nbsp;<br>Text&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="wfront">▤ In Front of Puzzle</button>
+                  <button type="button" data-act="wbehind">▥ Behind Puzzle</button>
+                </div>
+              </span>
+              <span class="rmini-grid">
+                <button id="sfForward" class="rmini" title="Bring forward"><span class="rmini-ico">⭱</span>Bring Forward</button>
+                <button id="sfBackward" class="rmini" title="Send backward"><span class="rmini-ico">⭳</span>Send Backward</button>
+                <span class="rdrop" id="sfAlignDrop">
+                  <button class="rmini rdrop-btn" id="sfAlignDropBtn" aria-haspopup="true" aria-expanded="false" title="Align or distribute"><span class="rmini-ico">⯐</span>Align&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="aleft">⯇ Align Left</button>
+                    <button type="button" data-act="acenter">≡ Align Center</button>
+                    <button type="button" data-act="aright">⯈ Align Right</button>
+                    <button type="button" data-act="atop">⤒ Align Top</button>
+                    <button type="button" data-act="amiddle">⇕ Align Middle</button>
+                    <button type="button" data-act="abottom">⤓ Align Bottom</button>
+                    <button type="button" data-act="disth">⇿ Distribute Horizontally</button>
+                    <button type="button" data-act="distv">⇳ Distribute Vertically</button>
+                  </div>
+                </span>
+                <button id="sfGroup" class="rmini" title="Group"><span class="rmini-ico">⊞</span>Group</button>
+                <button id="sfUngroup" class="rmini" title="Ungroup"><span class="rmini-ico">⊟</span>Ungroup</button>
+                <span class="rdrop" id="sfRotateDrop">
+                  <button class="rmini rdrop-btn" id="sfRotateDropBtn" aria-haspopup="true" aria-expanded="false" title="Rotate or flip"><span class="rmini-ico">⟳</span>Rotate&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="rright">⟳ Rotate Right 90°</button>
+                    <button type="button" data-act="rleft">⟲ Rotate Left 90°</button>
+                    <button type="button" data-act="flipv">⇅ Flip Vertical</button>
+                    <button type="button" data-act="fliph">⇆ Flip Horizontal</button>
+                    <button type="button" data-act="free">⌖ Free Rotate…</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Arrange</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col size-fields">
+                <label class="m"><span>Height</span><input id="sfH" type="number" min="4"></label>
+                <label class="m"><span>Width</span><input id="sfW" type="number" min="8"></label>
+              </span>
+            </div>
+            <div class="rgroup-name">Size</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- TABLE DESIGN (contextual: table styling) -->
+      <section class="ribbon-panel" data-panel="tabledesign">
+        <div id="tdNone" class="rhint">Select a table to change its style, fill, and borders.</div>
+        <div id="tdControls" class="ribbon-inline hidden">
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <div class="td-format-gallery" id="tdFormatGallery"></div>
+            </div>
+            <div class="rgroup-name">Table Formats</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <span class="rdrop" id="tdFillDrop">
+                  <button class="rmini rdrop-btn" id="tdFillDropBtn" aria-haspopup="true" aria-expanded="false" title="Cell fill"><span class="rmini-ico">🎨</span>Fill&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="tdFillMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="tdHeaderFillDrop">
+                  <button class="rmini rdrop-btn" id="tdHeaderFillDropBtn" aria-haspopup="true" aria-expanded="false" title="Header row fill"><span class="rmini-ico">▤</span>Header&nbsp;Fill&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="tdHeaderFillMenu" hidden></div>
+                </span>
+                <label class="rdrop-check tbl-headerchk"><input type="checkbox" id="tdHeader"> Header row</label>
+              </span>
+            </div>
+            <div class="rgroup-name">Fill</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <label class="m"><span>Weight</span><input id="tdBorderW" type="number" min="0" max="8" step="0.5" value="1"></label>
+                <span class="rdrop" id="tdLineColorDrop">
+                  <button class="rmini rdrop-btn" id="tdLineColorDropBtn" aria-haspopup="true" aria-expanded="false" title="Border line colour"><span class="rmini-ico">✎</span>Line&nbsp;Color&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="tdLineColorMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="tdBordersDrop">
+                  <button class="rmini rdrop-btn" id="tdBordersDropBtn" aria-haspopup="true" aria-expanded="false" title="Which borders to show"><span class="rmini-ico">▦</span>Borders&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="all">▦ All Borders</button>
+                    <button type="button" data-act="thin">─ Thin (½ pt)</button>
+                    <button type="button" data-act="thick">━ Thick (2 pt)</button>
+                    <button type="button" data-act="none">▢ No Borders</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Borders</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- TABLE LAYOUT (contextual: rows/cols, alignment, arrange) -->
+      <section class="ribbon-panel" data-panel="tablelayout">
+        <div id="tlNone" class="rhint">Select a table to add rows &amp; columns and arrange it.</div>
+        <div id="tlControls" class="ribbon-inline hidden">
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-grid">
+                <button id="tlInsAbove" class="rmini" title="Insert row above"><span class="rmini-ico">⬆</span>Insert Above</button>
+                <button id="tlInsBelow" class="rmini" title="Insert row below"><span class="rmini-ico">⬇</span>Insert Below</button>
+                <button id="tlInsLeft" class="rmini" title="Insert column left"><span class="rmini-ico">⬅</span>Insert Left</button>
+                <button id="tlInsRight" class="rmini" title="Insert column right"><span class="rmini-ico">➡</span>Insert Right</button>
+                <span class="rdrop" id="tlDeleteDrop">
+                  <button class="rmini rdrop-btn" id="tlDeleteDropBtn" aria-haspopup="true" aria-expanded="false" title="Delete rows or columns"><span class="rmini-ico">🗑</span>Delete&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="row">🗑 Delete Row</button>
+                    <button type="button" data-act="col">🗑 Delete Column</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Rows &amp; Columns</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <button id="tlMerge" class="rmini" title="Merge the selected cells (click a cell, Shift-click another)"><span class="rmini-ico">⬓</span>Merge Cells</button>
+                <button id="tlSplit" class="rmini" title="Split the merged cell under the selection"><span class="rmini-ico">⬒</span>Split Cells</button>
+                <button id="tlDiagonal" class="rmini" title="Toggle a diagonal line in the selected cell"><span class="rmini-ico">◹</span>Diagonals</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Merge</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="align-grid2">
+                <button class="iconbtn tbl-align" data-talign="left" title="Align left">⯇</button>
+                <button class="iconbtn tbl-align" data-talign="center" title="Center">≡</button>
+                <button class="iconbtn tbl-align" data-talign="right" title="Align right">⯈</button>
+                <button class="iconbtn" id="tlEditText" title="Edit cell text">✎</button>
+              </span>
+              <span class="rdrop" id="tlMarginsDrop">
+                <button class="rmini rdrop-btn" id="tlMarginsDropBtn" aria-haspopup="true" aria-expanded="false" title="Cell margins (padding)"><span class="rmini-ico">▤</span>Cell&nbsp;<br>Margins&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="none">None — 0</button>
+                  <button type="button" data-act="narrow">Narrow — 3px</button>
+                  <button type="button" data-act="moderate">Moderate — 6px</button>
+                  <button type="button" data-act="wide">Wide — 12px</button>
+                </div>
+              </span>
+            </div>
+            <div class="rgroup-name">Alignment</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rdrop" id="tlWrapDrop">
+                <button class="rbig rdrop-btn" id="tlWrapDropBtn" aria-haspopup="true" aria-expanded="false" title="How this table layers with the puzzle"><span class="rbig-ico">◲</span>Wrap&nbsp;<br>Text&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="wfront">▤ In Front of Puzzle</button>
+                  <button type="button" data-act="wbehind">▥ Behind Puzzle</button>
+                </div>
+              </span>
+              <span class="rmini-grid">
+                <button id="tlForward" class="rmini" title="Bring forward"><span class="rmini-ico">⭱</span>Bring Forward</button>
+                <button id="tlBackward" class="rmini" title="Send backward"><span class="rmini-ico">⭳</span>Send Backward</button>
+                <span class="rdrop" id="tlAlignDrop">
+                  <button class="rmini rdrop-btn" id="tlAlignDropBtn" aria-haspopup="true" aria-expanded="false" title="Align on the page"><span class="rmini-ico">⯐</span>Align&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="aleft">⯇ Align Left</button>
+                    <button type="button" data-act="acenter">≡ Align Center</button>
+                    <button type="button" data-act="aright">⯈ Align Right</button>
+                    <button type="button" data-act="atop">⤒ Align Top</button>
+                    <button type="button" data-act="amiddle">⇕ Align Middle</button>
+                    <button type="button" data-act="abottom">⤓ Align Bottom</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="tlRotateDrop">
+                  <button class="rmini rdrop-btn" id="tlRotateDropBtn" aria-haspopup="true" aria-expanded="false" title="Rotate or flip"><span class="rmini-ico">⟳</span>Rotate&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="rright">⟳ Rotate Right 90°</button>
+                    <button type="button" data-act="rleft">⟲ Rotate Left 90°</button>
+                    <button type="button" data-act="free">⌖ Free Rotate…</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Arrange</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- PICTURE FORMAT (contextual: image adjust / styles / arrange) -->
+      <section class="ribbon-panel" data-panel="pictureformat">
+        <div id="picNone" class="rhint">Select a picture to adjust, style, and arrange it.</div>
+        <div id="picControls" class="ribbon-inline hidden">
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <span class="rdrop" id="picCorrDrop">
+                  <button class="rmini rdrop-btn" id="picCorrDropBtn" aria-haspopup="true" aria-expanded="false" title="Brightness &amp; contrast"><span class="rmini-ico">☀</span>Corrections&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu pic-adjust-menu" id="picCorrMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="picRecolorDrop">
+                  <button class="rmini rdrop-btn" id="picRecolorDropBtn" aria-haspopup="true" aria-expanded="false" title="Recolor wash"><span class="rmini-ico">🎨</span>Recolor&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu pic-adjust-menu" id="picRecolorMenu" hidden></div>
+                </span>
+              </span>
+              <span class="rmini-col">
+                <label class="upload rmini" title="Replace this picture with another"><span class="rmini-ico">🔁</span>Change Picture<input id="picChange" type="file" accept="image/*" hidden></label>
+                <button id="picReset" class="rmini" title="Remove all adjustments"><span class="rmini-ico">↺</span>Reset Picture</button>
+              </span>
+              <span class="rmini-col">
+                <span class="rdrop" id="picCompressDrop">
+                  <button class="rmini rdrop-btn" id="picCompressDropBtn" aria-haspopup="true" aria-expanded="false" title="Shrink the stored image to a target print resolution"><span class="rmini-ico">🗜</span>Compress&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="ppi300">Print — 300 ppi (best)</button>
+                    <button type="button" data-act="ppi220">Print — 220 ppi</button>
+                    <button type="button" data-act="ppi150">On-screen — 150 ppi</button>
+                    <button type="button" data-act="ppi96">Web — 96 ppi (smallest)</button>
+                    <div class="rdrop-sep"></div>
+                    <label class="rdrop-check"><input type="checkbox" id="picCompressCrop" checked> Delete cropped areas</label>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Adjust</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <div class="wordart-gallery" id="picStyleGallery"></div>
+              <span class="rmini-col">
+                <span class="rdrop" id="picBorderDrop">
+                  <button class="rmini rdrop-btn" id="picBorderDropBtn" aria-haspopup="true" aria-expanded="false" title="Picture border"><span class="rmini-ico">▭</span>Picture&nbsp;Border&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu color-menu" id="picBorderMenu" hidden></div>
+                </span>
+                <span class="rdrop" id="picEffectsDrop">
+                  <button class="rmini rdrop-btn" id="picEffectsDropBtn" aria-haspopup="true" aria-expanded="false" title="Picture effects"><span class="rmini-ico">✦</span>Picture&nbsp;Effects&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="shadow">◍ Toggle shadow</button>
+                    <button type="button" data-act="round">▢ Toggle rounded corners</button>
+                    <button type="button" data-act="none">✕ Clear effects</button>
+                  </div>
+                </span>
+                <span class="rdrop" id="picCaptionDrop">
+                  <button class="rmini rdrop-btn" id="picCaptionDropBtn" aria-haspopup="true" aria-expanded="false" title="Caption"><span class="rmini-ico">🄰</span>Caption&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <label class="rdrop-field"><span>Text</span><input id="picCaptionText" type="text" placeholder="Caption…"></label>
+                    <div class="rdrop-sep"></div>
+                    <button type="button" data-act="none">✕ No Caption</button>
+                    <button type="button" data-act="below">▭ Below Picture</button>
+                    <button type="button" data-act="overlay">▄ Overlay Bar</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Picture Styles</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rdrop" id="picWrapDrop">
+                <button class="rbig rdrop-btn" id="picWrapDropBtn" aria-haspopup="true" aria-expanded="false" title="How this picture layers with the puzzle"><span class="rbig-ico">◲</span>Wrap&nbsp;<br>Text&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" hidden>
+                  <button type="button" data-act="wfront">▤ In Front of Puzzle</button>
+                  <button type="button" data-act="wbehind">▥ Behind Puzzle</button>
+                </div>
+              </span>
+              <span class="rmini-grid">
+                <button id="picForward" class="rmini" title="Bring forward"><span class="rmini-ico">⭱</span>Bring Forward</button>
+                <button id="picBackward" class="rmini" title="Send backward"><span class="rmini-ico">⭳</span>Send Backward</button>
+                <span class="rdrop" id="picAlignDrop">
+                  <button class="rmini rdrop-btn" id="picAlignDropBtn" aria-haspopup="true" aria-expanded="false" title="Align on the page"><span class="rmini-ico">⯐</span>Align&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="aleft">⯇ Align Left</button>
+                    <button type="button" data-act="acenter">≡ Align Center</button>
+                    <button type="button" data-act="aright">⯈ Align Right</button>
+                    <button type="button" data-act="atop">⤒ Align Top</button>
+                    <button type="button" data-act="amiddle">⇕ Align Middle</button>
+                    <button type="button" data-act="abottom">⤓ Align Bottom</button>
+                  </div>
+                </span>
+                <button id="picFlipH" class="rmini" title="Flip horizontal"><span class="rmini-ico">⇋</span>Flip H</button>
+                <button id="picFlipV" class="rmini" title="Flip vertical"><span class="rmini-ico">⇅</span>Flip V</button>
+                <button id="picSwap" class="rmini" title="Swap this picture's contents with another (select two, or click then pick)"><span class="rmini-ico">⇄</span>Swap</button>
+                <span class="rdrop" id="picRotateDrop">
+                  <button class="rmini rdrop-btn" id="picRotateDropBtn" aria-haspopup="true" aria-expanded="false" title="Rotate"><span class="rmini-ico">⟳</span>Rotate&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="rright">⟳ Rotate Right 90°</button>
+                    <button type="button" data-act="rleft">⟲ Rotate Left 90°</button>
+                    <button type="button" data-act="free">⌖ Free Rotate…</button>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div class="rgroup-name">Arrange</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col">
+                <button id="picCropBtn" class="rbig" title="Crop — drag the handles, then click Crop again (or Enter) to apply"><span class="rbig-ico">⛶</span>Crop</button>
+              </span>
+              <span class="rmini-col">
+                <button id="picCropReset" class="rmini" title="Remove the crop"><span class="rmini-ico">↺</span>Reset Crop</button>
+                <button id="picCropFill" class="rmini" title="Crop to a centered square"><span class="rmini-ico">▣</span>Crop to Square</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Crop</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col size-fields">
+                <label class="m"><span>Width</span><input id="picW" type="number" min="16"></label>
+              </span>
+            </div>
+            <div class="rgroup-name">Size</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- QR CODE (contextual: linked QR object — Data · Colours · Arrange · Size) -->
+      <section class="ribbon-panel" data-panel="qrformat">
+        <div id="qrNone" class="rhint">Select a QR code to edit its link, correction level, and colours.</div>
+        <div id="qrControls" class="ribbon-inline hidden">
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rdrop" id="qrLinkDrop">
+                <button class="rbig rdrop-btn" id="qrLinkDropBtn" aria-haspopup="true" aria-expanded="false" title="Edit the link or text this QR encodes"><span class="rbig-ico">🔗</span>Edit&nbsp;<br>Link&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" id="qrLinkMenu" hidden>
+                  <label class="rdrop-field qr-url"><span>Links to</span><input id="qrUrl" type="text" placeholder="https://…"></label>
+                  <div class="rdrop-note">A phone camera opens this address when it scans the printed code.</div>
+                </div>
+              </span>
+              <span class="rmini-col">
+                <span class="rdrop" id="qrEclDrop">
+                  <button class="rmini rdrop-btn" id="qrEclDropBtn" aria-haspopup="true" aria-expanded="false" title="Error correction: higher survives more damage but packs the code denser"><span class="rmini-ico">◈</span>Correction&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" id="qrEclMenu" hidden>
+                    <button type="button" data-act="L">L — Low (~7%)</button>
+                    <button type="button" data-act="M">M — Medium (~15%)</button>
+                    <button type="button" data-act="Q">Q — Quartile (~25%)</button>
+                    <button type="button" data-act="H">H — High (~30%)</button>
+                  </div>
+                </span>
+                <button id="qrTest" class="rmini" title="Open this link in a new tab to check it"><span class="rmini-ico">🔎</span>Test Link</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Data</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <div class="wordart-gallery" id="qrStyleGallery"></div>
+              <span class="rdrop" id="qrColorsDrop">
+                <button class="rmini rdrop-btn" id="qrColorsDropBtn" aria-haspopup="true" aria-expanded="false" title="Dark &amp; light colours"><span class="rmini-ico">🎨</span>Colours&nbsp;<span class="rdrop-caret">▾</span></button>
+                <div class="rdrop-menu" id="qrColorsMenu" hidden>
+                  <label class="rdrop-field"><span>Dark</span><input id="qrFg" type="color" value="#000000"></label>
+                  <label class="rdrop-field"><span>Light</span><input id="qrBg" type="color" value="#ffffff"></label>
+                  <label class="rdrop-check"><input type="checkbox" id="qrTransparent"> Transparent background</label>
+                  <div class="rdrop-sep"></div>
+                  <button type="button" class="rdrop-item" data-act="reset">↺ Black on white</button>
+                </div>
+              </span>
+            </div>
+            <div class="rgroup-name">Styles</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-grid">
+                <button id="qrForward" class="rmini" title="Bring forward"><span class="rmini-ico">⭱</span>Bring Forward</button>
+                <button id="qrBackward" class="rmini" title="Send backward"><span class="rmini-ico">⭳</span>Send Backward</button>
+                <span class="rdrop" id="qrAlignDrop">
+                  <button class="rmini rdrop-btn" id="qrAlignDropBtn" aria-haspopup="true" aria-expanded="false" title="Align on the page"><span class="rmini-ico">⯐</span>Align&nbsp;<span class="rdrop-caret">▾</span></button>
+                  <div class="rdrop-menu" hidden>
+                    <button type="button" data-act="aleft">⯇ Align Left</button>
+                    <button type="button" data-act="acenter">≡ Align Center</button>
+                    <button type="button" data-act="aright">⯈ Align Right</button>
+                    <button type="button" data-act="atop">⤒ Align Top</button>
+                    <button type="button" data-act="amiddle">⇕ Align Middle</button>
+                    <button type="button" data-act="abottom">⤓ Align Bottom</button>
+                  </div>
+                </span>
+                <button id="qrDup" class="rmini" title="Duplicate"><span class="rmini-ico">⧉</span>Duplicate</button>
+                <button id="qrReset" class="rmini" title="Reset size"><span class="rmini-ico">⟲</span>Reset Size</button>
+                <button id="qrHide" class="rmini" title="Hide"><span class="rmini-ico">🚫</span>Hide</button>
+              </span>
+            </div>
+            <div class="rgroup-name">Arrange</div>
+          </div>
+          <div class="rgroup">
+            <div class="rgroup-body">
+              <span class="rmini-col size-fields">
+                <label class="m"><span>Size</span><input id="qrW" type="number" min="24"></label>
+              </span>
+            </div>
+            <div class="rgroup-name">Size</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- VIEW (Publisher-style: Views · Layout · Show · Zoom) -->
+      <section class="ribbon-panel" data-panel="view">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="viewNormal" class="rbig on" title="Normal editing view"><span class="rbig-ico">📄</span>Normal</button>
+            <button id="viewMaster" class="rbig" title="Edit the master page (page numbers, headers, frames)"><span class="rbig-ico">🗐</span>Master<br>Page</button>
+          </div>
+          <div class="rgroup-name">Views</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="viewSingle" class="rbig on" title="Single-page view"><span class="rbig-ico">▯</span>Single<br>Page</button>
+            <button id="viewSpread" class="rbig" title="Two-page spread (facing pages)"><span class="rbig-ico">▭▭</span>Two-Page<br>Spread</button>
+            <input type="checkbox" id="spreadToggle" hidden>
+          </div>
+          <div class="rgroup-name">Layout</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="show-checks">
+              <label class="checkbox"><input type="checkbox" id="boundToggle"> Boundaries</label>
+              <label class="checkbox"><input type="checkbox" id="snapToggle" checked> Guides</label>
+              <label class="checkbox"><input type="checkbox" id="gridToggle"> Grid</label>
+              <label class="checkbox"><input type="checkbox" id="rulerToggle" checked> Rulers</label>
+              <label class="checkbox"><input type="checkbox" id="navToggle" checked> Page Navigation</label>
+              <label class="checkbox"><input type="checkbox" id="darkToggle" checked> Dark Theme</label>
+            </span>
+          </div>
+          <div class="rgroup-name">Show</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="zoom100" class="rbig" title="Actual size (100%)"><span class="rbig-ico rbig-aa">100</span>100%</button>
+            <button id="zoomWhole" class="rbig" title="Fit the whole page in view"><span class="rbig-ico">▭</span>Whole<br>Page</button>
+            <button id="zoomWidth" class="rbig" title="Fit the page to the window width"><span class="rbig-ico">↔</span>Page<br>Width</button>
+            <span class="zoombar">
+              <button id="zoomOut" class="iconbtn" title="Zoom out">−</button>
+              <span id="zoomLabel" class="zoom-label">100%</span>
+              <button id="zoomIn" class="iconbtn" title="Zoom in">+</button>
+              <button id="zoomFit" class="iconbtn" title="Fit whole page">⤢</button>
+            </span>
+          </div>
+          <div class="rgroup-name">Zoom</div>
+        </div>
+      </section>
+
+      <!-- HELP -->
+      <section class="ribbon-panel" data-panel="help">
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <button id="helpBtn" class="ghost" title="Browse help articles">❓ Help</button>
+            <button id="supportBtn" class="ghost" title="Report a bug or suggest a feature">🛟 Contact Support</button>
+            <button id="shortcutsBtn" class="ghost" title="Keyboard shortcuts">⌨ Shortcuts</button>
+          </div>
+          <div class="rgroup-name">Help</div>
+        </div>
+        <div class="rgroup">
+          <div class="rgroup-body">
+            <span class="design-info" id="verInfo">PuzzleForge Editor</span>
+          </div>
+          <div class="rgroup-name">About</div>
+        </div>
+      </section>
+    </div>
+  </header>
+
+  <p class="status editor-status" id="status"></p>
+
+  <div id="masterBanner" class="master-banner" hidden>
+    <span>✎ <b>Editing the Master Page</b> — objects here repeat on every page in scope. The <b>#️⃣</b> field becomes each page's number.</span>
+    <button id="exitMasterBtn" class="primary">Done editing master</button>
+  </div>
+
+  <main class="editor-layout ribbon-layout" id="editorMain" hidden>
+    <aside class="editor-pages" aria-label="Pages">
+      <h2>Pages</h2>
+      <ol id="pageList" class="page-list"></ol>
+      <div class="page-add">
+        <button id="addBlankSide" class="ghost" title="Insert a blank page after the current one">+ Blank page</button>
+        <button id="insertTplSide" class="ghost" title="Insert a page from a template">+ Page template…</button>
+      </div>
+      <p class="hint">Use ↑ ↓ to reorder, ⧉ to duplicate, ✕ to delete. Insert blank pages to
+        keep coloring/drawing backs empty and lay out your adventure book by hand.</p>
+    </aside>
+
+    <section class="editor-stage" aria-label="Canvas">
+      <div class="ruler-corner"></div>
+      <div class="ruler ruler-top" id="rulerTop"></div>
+      <div class="ruler ruler-left" id="rulerLeft"></div>
+      <div class="stage-scroll" id="stageScroll">
+        <div class="stage-outer" id="stageOuter">
+          <div class="stage-inner" id="stageInner"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="editor-empty" id="emptyState">
+    <p>Use <b>Open recipe</b> above to load a saved book (.json). A starter recipe ships at
+      <code>public/starter-recipe.json</code> if you want something to open first.</p>
+    <p class="hint">Drag to move; ○ handle resizes. Arrow keys nudge (Shift = 10px).
+      Ctrl+Z/Y undo/redo, Ctrl+C/V/D copy/paste/duplicate. Export composites everything at print resolution.</p>
+  </div>
+
+  <!-- Page-template picker -->
+  <div class="pf-modal" id="tplModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box" role="dialog" aria-modal="true" aria-labelledby="tplModalTitle">
+      <div class="pf-modal-head">
+        <h2 id="tplModalTitle">Insert page template</h2>
+        <button class="iconbtn" id="tplClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Drops a new page after the current one. Everything is editable — type over the
+        text, move it, or delete what you don't want.</p>
+      <h3 class="pf-tpl-group">Built-in</h3>
+      <div class="pf-tpl-grid" id="tplBuiltin"></div>
+      <h3 class="pf-tpl-group">Your saved templates <span id="tplSavedCount" class="pf-tpl-count"></span></h3>
+      <div class="pf-tpl-grid" id="tplSaved"></div>
+      <p class="pf-modal-sub" id="tplSavedEmpty">No saved templates yet. Build a page, then use
+        <b>Save as template…</b> to reuse it here.</p>
+    </div>
+  </div>
+
+  <!-- Change Template: visual previews, applied to the current page -->
+  <div class="pf-modal" id="changeTplModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box wide" role="dialog" aria-modal="true" aria-labelledby="changeTplTitle">
+      <div class="pf-modal-head">
+        <h2 id="changeTplTitle">Change template</h2>
+        <button class="iconbtn" id="changeTplClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Pick a layout to apply to <b id="changeTplPageName">this page</b>. It replaces the
+        page's current text &amp; shapes — everything stays editable afterward.</p>
+      <h3 class="pf-tpl-group">Built-in layouts</h3>
+      <div class="pf-tplchg-grid" id="changeTplBuiltin"></div>
+      <h3 class="pf-tpl-group">Your saved templates <span id="changeTplSavedCount" class="pf-tpl-count"></span></h3>
+      <div class="pf-tplchg-grid" id="changeTplSaved"></div>
+      <p class="pf-modal-sub" id="changeTplSavedEmpty">No saved templates yet. Build a page, then use
+        <b>Insert → Save as Template</b> to reuse it here.</p>
+    </div>
+  </div>
+
+  <!-- Insert a generated puzzle -->
+  <div class="pf-modal" id="puzModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box" role="dialog" aria-modal="true" aria-labelledby="puzTitle">
+      <div class="pf-modal-head">
+        <h2 id="puzTitle">Insert puzzle</h2>
+        <button class="iconbtn" id="puzClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Generates a fresh puzzle from this book's theme and audience, and drops it in
+        after the current page.</p>
+      <label class="field compact"><span>Puzzle type</span><select id="puzType"></select></label>
+      <label class="field compact" id="puzColorRow" hidden><span>Coloring style</span>
+        <select id="puzColorStyle"><option value="">Auto</option><option value="mandala">Mandala</option><option value="pattern">Pattern</option><option value="bubble">Bubble letters</option></select>
+      </label>
+      <label class="field compact"><span>Theme</span><select id="puzTheme"></select></label>
+      <div class="row">
+        <label class="field compact"><span>Audience</span>
+          <select id="puzAudience"><option value="kids">Kids</option><option value="adult">Adult</option></select>
+        </label>
+        <label class="field compact"><span>Difficulty</span><select id="puzDiff"></select></label>
+      </div>
+      <label class="field compact"><span>How many</span><input id="puzCount" type="number" min="1" max="50" value="1"></label>
+      <div class="actions">
+        <button id="puzInsert" class="primary">Insert</button>
+        <button class="ghost" data-close>Cancel</button>
+      </div>
+      <p class="status" id="puzStatus"></p>
+    </div>
+  </div>
+
+  <!-- Find & Replace -->
+  <div class="pf-modal" id="frModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-fr" role="dialog" aria-modal="true" aria-labelledby="frTitle">
+      <div class="pf-modal-head">
+        <h2 id="frTitle">Find &amp; Replace</h2>
+        <button class="iconbtn" id="frClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Searches the text you've added (titles, matter, labels) across every page.</p>
+      <label class="field compact"><span>Find</span><input id="frFind" type="text" placeholder="text to find"></label>
+      <label class="field compact"><span>Replace with</span><input id="frReplace" type="text" placeholder="replacement (leave blank to delete)"></label>
+      <label class="checkbox"><input type="checkbox" id="frCase"> Match case</label>
+      <div class="pf-pub-footer">
+        <button id="frReplaceAll" class="primary">Replace all</button>
+        <span id="frStatus" class="pf-pub-status"></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Publish: pre-flight + KDP package export -->
+  <div class="pf-modal" id="pubModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-pub" role="dialog" aria-modal="true" aria-labelledby="pubTitle">
+      <div class="pf-modal-head">
+        <h2 id="pubTitle">Publish to KDP</h2>
+        <button class="iconbtn" id="pubClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Runs a pre-flight check and proofread, then bundles everything KDP needs into one
+        download. Nothing here changes your book — you can export even with warnings.</p>
+
+      <div class="pf-pub-actions">
+        <button id="pubRunChecks" class="ghost">▶ Run pre-flight &amp; proofread</button>
+        <span id="pubCheckStatus" class="pf-pub-status"></span>
+      </div>
+      <div id="pubReport" class="pf-report" hidden></div>
+
+      <h3 class="pf-tpl-group">Listing details</h3>
+      <div class="pf-pub-grid">
+        <label class="field compact"><span>List price (USD)</span><input id="pubPrice" type="number" min="0" step="0.01" placeholder="e.g. 7.99"></label>
+        <label class="field compact"><span>Paper</span>
+          <select id="pubPaper"><option value="white">White</option><option value="cream">Cream</option></select>
+        </label>
+        <label class="field compact"><span>Reading age</span><input id="pubAge" type="text" placeholder="e.g. 6–10"></label>
+      </div>
+      <label class="field compact"><span>Description / blurb</span><textarea id="pubDesc" rows="3" placeholder="Back-cover blurb and KDP description…"></textarea></label>
+      <div class="pf-pub-grid">
+        <label class="field compact"><span>Keywords (comma-separated, 7 max)</span><input id="pubKeywords" type="text" placeholder="mazes, kids activity, ages 6-8, …"></label>
+        <label class="field compact"><span>Categories (comma-separated, 3 max)</span><input id="pubCategories" type="text" placeholder="Children's puzzle books, …"></label>
+      </div>
+      <div class="pf-pub-checks">
+        <label class="checkbox"><input type="checkbox" id="pubAiText"> Book uses AI-generated text (themes / clues)</label>
+        <label class="checkbox"><input type="checkbox" id="pubAiImages"> Book uses AI-generated images</label>
+      </div>
+
+      <h3 class="pf-tpl-group">Cover</h3>
+      <div id="pubCoverStatus" class="pf-cover-status"></div>
+      <div class="pf-pub-actions">
+        <button id="pubClearCover" class="ghost" type="button" hidden>Use simple cover instead</button>
+      </div>
+      <div id="pubSimpleCover" class="pf-pub-grid">
+        <label class="field compact"><span>Background</span><input id="pubCoverBg" type="color" value="#2b5f6e"></label>
+        <label class="field compact"><span>Text color</span><input id="pubCoverText" type="color" value="#ffffff"></label>
+      </div>
+
+      <div class="pf-pub-footer">
+        <button id="pubExport" class="primary">⬇ Export KDP package (.zip)</button>
+        <span id="pubExportStatus" class="pf-pub-status"></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Review: spelling / thesaurus / word count results -->
+  <div class="pf-modal" id="revModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-pub" role="dialog" aria-modal="true" aria-labelledby="revTitle">
+      <div class="pf-modal-head">
+        <h2 id="revTitle">Review</h2>
+        <button class="iconbtn" id="revClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub" id="revSub"></p>
+      <div id="revBody" class="pf-report"></div>
+    </div>
+  </div>
+
+  <!-- Help Center: searchable articles -->
+  <div class="pf-modal" id="helpModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-help" role="dialog" aria-modal="true" aria-labelledby="helpTitle">
+      <div class="pf-modal-head">
+        <h2 id="helpTitle">Help Center</h2>
+        <button class="iconbtn" id="helpClose" title="Close" data-close>✕</button>
+      </div>
+      <input id="helpSearch" class="pf-help-search" type="search" placeholder="Search help… (e.g. “export”, “template”, “KDP”)" autocomplete="off">
+      <div class="pf-help-body">
+        <nav class="pf-help-cats" id="helpCats"></nav>
+        <div class="pf-help-articles" id="helpArticles"></div>
+      </div>
+      <div class="pf-help-foot">
+        Can’t find an answer? <button id="helpToSupport" class="linkbtn" type="button">Contact Support →</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Contact Support: bug report / feature suggestion → GitHub issue -->
+  <div class="pf-modal" id="supportModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-pub" role="dialog" aria-modal="true" aria-labelledby="supportTitle">
+      <div class="pf-modal-head">
+        <h2 id="supportTitle">Contact Support</h2>
+        <button class="iconbtn" id="supportClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Report a bug or suggest a feature. Submitting opens a pre-filled issue on our
+        GitHub — you can review it before posting (a free GitHub account is needed to post).</p>
+      <div class="pf-pub-grid">
+        <label class="field compact"><span>Type</span>
+          <select id="supType">
+            <option value="bug">🐛 Bug report</option>
+            <option value="feature">💡 Feature suggestion</option>
+            <option value="question">❓ Question</option>
+          </select>
+        </label>
+        <label class="field compact"><span>Summary</span><input id="supTitle" type="text" placeholder="One-line summary"></label>
+      </div>
+      <label class="field compact"><span>Details</span><textarea id="supBody" rows="5" placeholder="What happened, what you expected, and steps to reproduce (for bugs)…"></textarea></label>
+      <label class="checkbox"><input type="checkbox" id="supIncludeCtx" checked> Include book &amp; browser details (trim size, page count, browser) — helps us debug</label>
+      <div class="pf-pub-footer">
+        <button id="supSubmit" class="primary">Open GitHub issue →</button>
+        <a id="supBrowse" class="linkbtn" href="#" target="_blank" rel="noopener">Browse existing issues</a>
+        <span id="supStatus" class="pf-pub-status"></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Team roster -->
+  <div class="pf-modal" id="teamModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-pub" role="dialog" aria-modal="true" aria-labelledby="teamTitle">
+      <div class="pf-modal-head">
+        <h2 id="teamTitle">Team Roster</h2>
+        <button class="iconbtn" id="teamClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub">Add the people you work with. Everything here is stored in this browser for now —
+        invites and handoffs open a pre-filled email you send yourself. (Real accounts &amp; shared sync come later.)</p>
+      <div class="pf-team-add">
+        <input id="teamName" type="text" placeholder="Name">
+        <input id="teamEmail" type="email" placeholder="Email">
+        <select id="teamRole">
+          <option value="Writer">Writer</option>
+          <option value="Editor">Editor</option>
+          <option value="Illustrator">Illustrator</option>
+          <option value="Reviewer">Reviewer</option>
+          <option value="Owner">Owner</option>
+        </select>
+        <button id="teamAdd" class="primary" type="button">Add</button>
+      </div>
+      <div id="teamList" class="pf-team-list"></div>
+      <p class="pf-modal-sub pf-help-note"><b>Personalized link:</b> each member gets a unique link that opens
+        PuzzleForge already identifying them — they’re greeted by name and their handoff notes are attributed to
+        their role. Send each person their own link so contributions are always tagged to the right person.</p>
+    </div>
+  </div>
+
+  <!-- Handoff notes -->
+  <div class="pf-modal" id="notesModal" hidden>
+    <div class="pf-modal-backdrop" data-close></div>
+    <div class="pf-modal-box pf-pub" role="dialog" aria-modal="true" aria-labelledby="notesTitle">
+      <div class="pf-modal-head">
+        <h2 id="notesTitle">Handoff Notes</h2>
+        <button class="iconbtn" id="notesClose" title="Close" data-close>✕</button>
+      </div>
+      <p class="pf-modal-sub" id="notesSub">Notes travel with this book so the next person has context. Saved with
+        your recipe on <b>Save</b>.</p>
+      <div id="notesList" class="pf-notes-list"></div>
+      <div class="pf-notes-add">
+        <textarea id="noteText" rows="2" placeholder="Add a note for the team…"></textarea>
+        <button id="noteAdd" class="primary" type="button">Post note</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="identity.js"></script>
+  <script src="qrcode-generator.js"></script>
+  <script src="element-html.js"></script>
+  <script src="decor.js"></script>
+  <script src="library.js"></script>
+  <script src="editor.js"></script>
+</body>
+</html>

--- a/publisher/public/editor.js
+++ b/publisher/public/editor.js
@@ -1,0 +1,3822 @@
+/* PuzzleForge — Page Editor (v4). Pieces render in their ORIGINAL flow layout
+ * (so an un-edited page is identical to the normal puzzle) and are moved with a
+ * transform delta; text and clip art are absolute overlays. Includes undo/redo,
+ * zoom + rulers, numeric panel, snapping/grid, multi-select, align/distribute,
+ * arrange, flip, lock, duplicate/copy/paste. Export composites at print res. */
+(function () {
+  'use strict';
+  const $ = (id) => document.getElementById(id);
+  const PX_PER_IN = 96, GRID = 24;
+  const el = {
+    status: $('status'), main: $('editorMain'), empty: $('emptyState'), pageList: $('pageList'), addBlank: $('addBlank'),
+    stageScroll: $('stageScroll'), stageOuter: $('stageOuter'), stageInner: $('stageInner'),
+    rulerTop: $('rulerTop'), rulerLeft: $('rulerLeft'),
+    undo: $('undo'), redo: $('redo'), zoomOut: $('zoomOut'), zoomIn: $('zoomIn'), zoomFit: $('zoomFit'), zoomLabel: $('zoomLabel'),
+    zoom100: $('zoom100'), zoomWhole: $('zoomWhole'), zoomWidth: $('zoomWidth'),
+    rulerToggle: $('rulerToggle'), navToggle: $('navToggle'), boundToggle: $('boundToggle'), editorMain: $('editorMain'), spreadToggle: $('spreadToggle'),
+    viewNormal: $('viewNormal'), viewMaster: $('viewMaster'), viewSingle: $('viewSingle'), viewSpread: $('viewSpread'),
+    addText: $('addText'), addImage: $('addImage'), addPicPlaceholder: $('addPicPlaceholder'), addTable: $('addTable'), addQr: $('addQr'),
+    addCalendarBtn: $('addCalendarBtn'), insLinkBtn: $('insLinkBtn'), insBookmarkBtn: $('insBookmarkBtn'),
+    qrControls: $('qrControls'), qrNone: $('qrNone'), qrUrl: $('qrUrl'), qrFg: $('qrFg'), qrBg: $('qrBg'),
+    qrTransparent: $('qrTransparent'), qrW: $('qrW'), qrTest: $('qrTest'), qrEclDropBtn: $('qrEclDropBtn'),
+    qrForward: $('qrForward'), qrBackward: $('qrBackward'), qrDup: $('qrDup'), qrReset: $('qrReset'), qrHide: $('qrHide'),
+    tableProps: $('tableProps'), tblAddRow: $('tblAddRow'), tblDelRow: $('tblDelRow'), tblAddCol: $('tblAddCol'), tblDelCol: $('tblDelCol'),
+    tblBorder: $('tblBorder'), tblHeaderFill: $('tblHeaderFill'), tblHeader: $('tblHeader'),
+    ctxTab: $('ctxTab'), ctxTab2: $('ctxTab2'), ctxTabTD: $('ctxTabTD'), ctxTabTL: $('ctxTabTL'), ctxTabPic: $('ctxTabPic'), ctxTabQr: $('ctxTabQr'),
+    picControls: $('picControls'), picNone: $('picNone'), picChange: $('picChange'), picReset: $('picReset'),
+    picForward: $('picForward'), picBackward: $('picBackward'), picFlipH: $('picFlipH'), picFlipV: $('picFlipV'), picW: $('picW'), picCaptionText: $('picCaptionText'),
+    picCropBtn: $('picCropBtn'), picCropReset: $('picCropReset'), picCropFill: $('picCropFill'),
+    picSwap: $('picSwap'), picCompressCrop: $('picCompressCrop'),
+    tdControls: $('tdControls'), tdNone: $('tdNone'), tdBorderW: $('tdBorderW'), tdHeader: $('tdHeader'),
+    tlControls: $('tlControls'), tlNone: $('tlNone'), tlEditText: $('tlEditText'), tlForward: $('tlForward'), tlBackward: $('tlBackward'),
+    tlInsAbove: $('tlInsAbove'), tlInsBelow: $('tlInsBelow'), tlInsLeft: $('tlInsLeft'), tlInsRight: $('tlInsRight'),
+    tlMerge: $('tlMerge'), tlSplit: $('tlSplit'), tlDiagonal: $('tlDiagonal'),
+    sfControls: $('sfControls'), sfNone: $('sfNone'), sfEditText: $('sfEditText'),
+    sfForward: $('sfForward'), sfBackward: $('sfBackward'), sfGroup: $('sfGroup'), sfUngroup: $('sfUngroup'), sfH: $('sfH'), sfW: $('sfW'),
+    selNone: $('selNone'), selControls: $('selControls'), measurePanel: $('measurePanel'),
+    mX: $('mX'), mY: $('mY'), mScale: $('mScale'), mRot: $('mRot'),
+    mW: $('mW'), mH: $('mH'), mWField: $('mWField'), mHField: $('mHField'),
+    fontSize: $('fontSize'), objColor: $('objColor'), tbHyphenBtn: $('tbHyphenBtn'),
+    tbLinkCreate: $('tbLinkCreate'), tbLinkBreak: $('tbLinkBreak'), tbLinkPrev: $('tbLinkPrev'), tbLinkNext: $('tbLinkNext'), tbStyDrop: $('tbStyDrop'),
+    fontFamily: $('fontFamily'), boldBtn: $('boldBtn'), italicBtn: $('italicBtn'), underBtn: $('underBtn'),
+    fontGrow: $('fontGrow'), fontShrink: $('fontShrink'), caseBtn: $('caseBtn'), clearFmt: $('clearFmt'), lineSpacing: $('lineSpacing'),
+    cutBtn: $('cutBtn'), copyBtn: $('copyBtn'), pasteBtn: $('pasteBtn'), fmtPainter: $('fmtPainter'),
+    hAddText: $('hAddText'), hAddImage: $('hAddImage'), hForward: $('hForward'), hBackward: $('hBackward'),
+    hGroup: $('hGroup'), hUngroup: $('hUngroup'), findReplaceBtn: $('findReplaceBtn'), selectAllBtn: $('selectAllBtn'), breakApartBtn: $('breakApartBtn'),
+    frModal: $('frModal'), frClose: $('frClose'), frFind: $('frFind'), frReplace: $('frReplace'), frCase: $('frCase'), frReplaceAll: $('frReplaceAll'), frStatus: $('frStatus'),
+    shapeProps: $('shapeProps'), fillColor: $('fillColor'), strokeColor: $('strokeColor'), strokeW: $('strokeW'), noFill: $('noFill'),
+    groupBtn: $('groupBtn'), ungroupBtn: $('ungroupBtn'), borderAll: $('borderAll'),
+    distH: $('distH'), distV: $('distV'),
+    toFront: $('toFront'), forward: $('forward'), backward: $('backward'), toBack: $('toBack'),
+    flipH: $('flipH'), flipV: $('flipV'), lockObj: $('lockObj'),
+    dupObj: $('dupObj'), resetPos: $('resetPos'), hideObj: $('hideObj'), deleteObj: $('deleteObj'),
+    border: $('border'), snapToggle: $('snapToggle'), gridToggle: $('gridToggle'),
+    reroll: $('reroll'), resetLayout: $('resetLayout'), addBlankSide: $('addBlankSide'), darkToggle: $('darkToggle'),
+    insertTpl: $('insertTpl'), insertTplSide: $('insertTplSide'), savePageTpl: $('savePageTpl'),
+    dupPage: $('dupPage'), aiArtBtn: $('aiArtBtn'), wordArt: $('wordArt'), symbolPick: $('symbolPick'), insertDate: $('insertDate'),
+    trimInfo: $('trimInfo'), sizeInfo: $('sizeInfo'), orientInfo: $('orientInfo'), marginGuide: $('marginGuide'), renamePage: $('renamePage'), delPage: $('delPage'),
+    alignGuidesChk: $('alignGuidesChk'), alignObjectsChk: $('alignObjectsChk'),
+    movePageUp: $('movePageUp'), movePageDown: $('movePageDown'), schemeGallery: $('schemeGallery'),
+    masterEnabled: $('masterEnabled'), editMasterBtn: $('editMasterBtn'), insertPageNo: $('insertPageNo'),
+    insHeader: $('insHeader'), insFooter: $('insFooter'),
+    masterApplyTo: $('masterApplyTo'), masterSkip: $('masterSkip'), masterStart: $('masterStart'),
+    masterBanner: $('masterBanner'), exitMasterBtn: $('exitMasterBtn'),
+    revSpelling: $('revSpelling'), revThesaurus: $('revThesaurus'), revWordCount: $('revWordCount'), revLanguage: $('revLanguage'),
+    revModal: $('revModal'), revClose: $('revClose'), revTitle: $('revTitle'), revSub: $('revSub'), revBody: $('revBody'),
+    helpBtn: $('helpBtn'), supportBtn: $('supportBtn'), shortcutsBtn: $('shortcutsBtn'),
+    helpModal: $('helpModal'), helpClose: $('helpClose'), helpSearch: $('helpSearch'), helpCats: $('helpCats'),
+    helpArticles: $('helpArticles'), helpToSupport: $('helpToSupport'),
+    supportModal: $('supportModal'), supportClose: $('supportClose'), supType: $('supType'), supTitle: $('supTitle'),
+    supBody: $('supBody'), supIncludeCtx: $('supIncludeCtx'), supSubmit: $('supSubmit'), supBrowse: $('supBrowse'), supStatus: $('supStatus'),
+    shareTeamBtn: $('shareTeamBtn'), saveMineBtn: $('saveMineBtn'), wsStatus: $('wsStatus'),
+    teamBtn: $('teamBtn'), inviteBtn: $('inviteBtn'), mailRecipient: $('mailRecipient'), emailBookBtn: $('emailBookBtn'),
+    linkBtn: $('linkBtn'), mailStage: $('mailStage'), assignBtn: $('assignBtn'), notesBtn: $('notesBtn'),
+    teamModal: $('teamModal'), teamClose: $('teamClose'), teamName: $('teamName'), teamEmail: $('teamEmail'),
+    teamRole: $('teamRole'), teamAdd: $('teamAdd'), teamList: $('teamList'),
+    notesModal: $('notesModal'), notesClose: $('notesClose'), notesSub: $('notesSub'), notesList: $('notesList'),
+    noteText: $('noteText'), noteAdd: $('noteAdd'),
+    tplModal: $('tplModal'), tplClose: $('tplClose'), tplBuiltin: $('tplBuiltin'), tplSaved: $('tplSaved'),
+    tplSavedCount: $('tplSavedCount'), tplSavedEmpty: $('tplSavedEmpty'),
+    changeTplBtn: $('changeTplBtn'), changeTplModal: $('changeTplModal'), changeTplClose: $('changeTplClose'),
+    changeTplBuiltin: $('changeTplBuiltin'), changeTplSaved: $('changeTplSaved'),
+    changeTplSavedCount: $('changeTplSavedCount'), changeTplSavedEmpty: $('changeTplSavedEmpty'),
+    changeTplPageName: $('changeTplPageName'),
+    fontUpload: $('fontUpload'),
+    bgColors: $('bgColors'), bgColor: $('bgColor'), bgColor2: $('bgColor2'), bgAngle: $('bgAngle'),
+    bgColor2Field: $('bgColor2Field'), bgAngleField: $('bgAngleField'),
+    puzModal: $('puzModal'), puzClose: $('puzClose'), puzType: $('puzType'), puzTheme: $('puzTheme'),
+    puzAudience: $('puzAudience'), puzDiff: $('puzDiff'), puzColorRow: $('puzColorRow'), puzColorStyle: $('puzColorStyle'),
+    puzCount: $('puzCount'), puzInsert: $('puzInsert'), puzStatus: $('puzStatus'),
+    publishBtn: $('publishBtn'), pubModal: $('pubModal'), pubClose: $('pubClose'),
+    pubRunChecks: $('pubRunChecks'), pubCheckStatus: $('pubCheckStatus'), pubReport: $('pubReport'),
+    pubPrice: $('pubPrice'), pubPaper: $('pubPaper'), pubAge: $('pubAge'), pubDesc: $('pubDesc'),
+    pubKeywords: $('pubKeywords'), pubCategories: $('pubCategories'), pubAiText: $('pubAiText'), pubAiImages: $('pubAiImages'),
+    pubCoverBg: $('pubCoverBg'), pubCoverText: $('pubCoverText'), pubExport: $('pubExport'), pubExportStatus: $('pubExportStatus'),
+    pubCoverStatus: $('pubCoverStatus'), pubOpenCover: $('pubOpenCover'), pubClearCover: $('pubClearCover'), pubSimpleCover: $('pubSimpleCover'),
+    save: $('save'), exportPdf: $('exportPdf'), loadRecipe: $('loadRecipe'), saveState: $('saveState'),
+  };
+  let bookId = null, bookConfig = null, seed = null, dims = { usableWidth: 636, usableHeight: 816 };
+  // Autosave to the My Books library (IndexedDB, this browser).
+  let currentLibId = null, bookOpen = false, lastSavedJson = null;
+  // Team workspace (self-hosted LAN server): whether it's reachable, and this
+  // book's shared id once it has been shared.
+  let wsEnabled = false, workspaceId = null, wsSub = null, detached = false;
+  let pageModels = [], srcPages = [], pendingPlan = null, cur = -1, uid = 1, zoom = 1;
+  let sels = [], clipboard = [];
+  let vGuide = null, hGuide = null, gridEl = null, selLayer = null, flowEl = null;
+  let ribbonActivate = null, ribbonPrevTab = 'home';
+  let lastProofIssues = [];
+  // Master page: an overlay of free elements repeated across pages. `masterMode`
+  // swaps the canvas to editing the master itself (via curModel()).
+  let master = { enabled: true, applyTo: 'all', skipFirst: 1, startAt: 1, elements: [] };
+  let masterMode = false;
+  // When a book is imported from the Book Builder, auto-break each puzzle page
+  // (title / instructions / word list → editable text) the first time it's
+  // shown, so the generated labels are editable without a manual click.
+  let autoBreak = false;
+  // Page Design → Layout: what dragged objects snap to, and the margin-guide inset.
+  let alignGuides = true, alignObjects = true;
+  let marginInset = GRID; // px; 0.25in default (Narrow)
+  const masterModel = { role: 'master', matterKind: null, blank: true, type: 'master', title: 'Master', comps: [], elements: master.elements, style: '', _border: '', undo: [], redo: [] };
+  const curModel = () => (masterMode ? masterModel : pageModels[cur]);
+  const num = (v, d) => (Number.isFinite(Number(v)) ? Number(v) : d);
+  const setStatus = (t, k) => { el.status.textContent = t || ''; el.status.className = 'status editor-status' + (k ? ' ' + k : ''); };
+  const slug = (s) => (s || 'book').replace(/[^a-z0-9]+/gi, '-').toLowerCase().replace(/^-+|-+$/g, '') || 'book';
+  const escHtml = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  function scopeCss(css, scope) {
+    css = css.replace(/@page[^{]*\{[^}]*\}/gi, ''); let out = ''; const re = /([^{}]+)\{([^}]*)\}/g; let m;
+    while ((m = re.exec(css)) !== null) {
+      const decl = m[2].trim(); if (!decl) continue;
+      const ss = m[1].split(',').map((s) => s.trim()).filter(Boolean).map((s) => s === '*' ? scope + ' *' : (s === 'html' || s === 'body') ? scope : /^(html|body)\b/.test(s) ? s.replace(/^(html|body)\b/, scope) : scope + ' ' + s);
+      out += ss.join(', ') + '{' + decl + '}\n';
+    }
+    return out;
+  }
+
+  // --- model ---
+  function buildComps(components) {
+    const seen = {};
+    return components.map((c) => {
+      const n = (seen[c.kind] = (seen[c.kind] || 0) + 1);
+      const key = n > 1 ? c.kind + n : c.kind;
+      return { group: 'piece', kind: c.kind, key, html: c.html, dx: 0, dy: 0, scale: 1, rot: 0, hidden: false, locked: false, baseX: 0, baseY: 0, baseW: 0, baseH: 0 };
+    });
+  }
+  // Apply a saved per-page state (layout deltas + overlays + border) onto a model.
+  function restoreState(m, state) {
+    const saved = state && state.layout;
+    if (saved) {
+      const cm = saved.comp || {};
+      m.comps.forEach((c) => {
+        const s = cm[c.key]; if (!s) return;
+        Object.assign(c, { dx: num(s.dx, 0), dy: num(s.dy, 0), scale: num(s.scale, 1), rot: num(s.rot, 0), hidden: !!s.hidden, locked: !!s.locked });
+        if (s.gid) c.gid = s.gid;
+        // Restore a matter piece's measured anchor so export matches the editor.
+        if (Number.isFinite(Number(s.ax))) { c.baseX = num(s.ax, 0); c.baseY = num(s.ay, 0); c.baseW = num(s.aw, 0); m._measured = true; }
+      });
+      m.elements = (saved.elements || []).map((e) => ({ ...e, group: 'el', id: e.id || uid++ }));
+    }
+    if (state && state.border) m._border = state.border;
+    if (state && state.borderColor) m._borderColor = state.borderColor;
+    if (state && state.bg && state.bg.type) m._bg = state.bg;
+    if (state && state.guides) m.guides = { v: (state.guides.v || []).map(Number), h: (state.guides.h || []).map(Number) };
+    return m;
+  }
+  function modelFromPage(p) {
+    const m = {
+      role: p.role || 'content', matterKind: p.matterKind || null, src: p.src != null ? p.src : null,
+      akIndex: p.akIndex != null ? p.akIndex : null,
+      blank: false, type: p.type || '', title: p.title || p.type || '', activity: !!p.activity,
+      style: p.style || '', comps: buildComps(p.components || []), elements: [], _border: '', undo: [], redo: [],
+      // Editor-inserted puzzle pages carry their own puzzle object (no src).
+      puzzle: p.puzzle || null,
+    };
+    return restoreState(m, p.state);
+  }
+  // Rebuild pageModels from a saved page plan (final order, blanks, per-page
+  // state), sourcing real pages fresh from the server's original leaf list.
+  function applyPlan(plan) {
+    const findSrc = (e) => {
+      if (e.role === 'frontmatter' || e.role === 'backmatter') return srcPages.find((sp) => sp.role === e.role && sp.matterKind === e.matterKind);
+      if (e.role === 'answerkey') return srcPages.find((sp) => sp.role === 'answerkey' && (sp.akIndex || 0) === (e.akIndex || 0)) || srcPages.find((sp) => sp.role === 'answerkey');
+      if (e.role === 'title') return srcPages.find((sp) => sp.role === 'title');
+      if (e.role === 'content' || (!e.role && e.src != null)) return srcPages.find((sp) => sp.role === 'content' && sp.src === e.src);
+      return null;
+    };
+    const rebuilt = plan.map((entry) => {
+      if (!entry) return null;
+      if (entry.blank || entry.role === 'blank') return restoreState(blankModel(), entry.state);
+      // Editor-inserted puzzle page: rebuild from the plan's own render cache.
+      if (entry.role === 'content' && entry.puzzle && entry.page) {
+        return restoreState(modelFromPage({
+          role: 'content', type: entry.page.type, title: entry.page.title, activity: true,
+          style: entry.page.style, components: entry.page.components, puzzle: entry.puzzle,
+        }), entry.state);
+      }
+      const sp = findSrc(entry); if (!sp) return null;
+      return restoreState(modelFromPage(sp), entry.state);
+    }).filter(Boolean);
+    if (rebuilt.length) pageModels = rebuilt;
+  }
+  // A user-inserted blank page (empty; can carry text/image overlays).
+  function blankModel() {
+    return { role: 'blank', matterKind: null, src: null, akIndex: null, blank: true, type: 'bleedguard', title: 'Blank', activity: true, style: '', comps: [], elements: [], _border: '', undo: [], redo: [] };
+  }
+  // Deep-copy a page model for duplication (keeps its role/src so export reuses
+  // the same source; fresh element ids so overlays are independent).
+  function clonePageModel(pm) {
+    return {
+      role: pm.role, matterKind: pm.matterKind, src: pm.src, akIndex: pm.akIndex, blank: pm.blank, type: pm.type, title: pm.title, activity: pm.activity,
+      style: pm.style,
+      comps: pm.comps.map((c) => ({ group: 'piece', kind: c.kind, key: c.key, html: c.html, dx: c.dx, dy: c.dy, scale: c.scale, rot: c.rot, hidden: c.hidden, locked: c.locked, baseX: 0, baseY: 0, baseW: 0, baseH: 0 })),
+      elements: pm.elements.map((e) => { const { _node, ...r } = e; return { ...r, id: uid++ }; }),
+      _border: pm._border, _borderColor: pm._borderColor, name: pm.name || null, undo: [], redo: [],
+      puzzle: pm.puzzle || null,
+    };
+  }
+
+  async function openBook(payload) {
+    setStatus('Opening book in the editor…', 'busy');
+    try {
+      const res = await fetch('/api/book/editor', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+      const data = await res.json(); if (!res.ok) throw new Error(data.error || 'Could not open the book');
+      bookId = data.bookId; seed = data.seed; dims = data.dims;
+      srcPages = data.pages || [];
+      pageModels = srcPages.map(modelFromPage);
+      if (pendingPlan) { applyPlan(pendingPlan); pendingPlan = null; }
+      el.empty.hidden = true; el.main.hidden = false;
+      if (el.trimInfo && dims) el.trimInfo.textContent = `${dims.widthIn}" × ${dims.heightIn}" trim`;
+      if (dims) {
+        if (el.sizeInfo) el.sizeInfo.textContent = `${dims.widthIn} × ${dims.heightIn} in`;
+        if (el.orientInfo) el.orientInfo.textContent = dims.heightIn >= dims.widthIn ? 'Portrait' : 'Landscape';
+      }
+      if (el.revLanguage && bookConfig && bookConfig.language) el.revLanguage.value = bookConfig.language;
+      loadTeamState();
+      if (bookConfig && bookConfig.master && typeof bookConfig.master === 'object') {
+        master = Object.assign({ enabled: true, applyTo: 'all', skipFirst: 1, startAt: 1, elements: [] }, bookConfig.master);
+        if (!Array.isArray(master.elements)) master.elements = [];
+      }
+      masterMode = false; updateMasterUI(); syncMasterScopeUI();
+      await loadBorderStyles(); buildPageList(); cur = 0; zoom = fitScale(); renderPage();
+      setStatus(inviteGreeting || `Editing “${data.title}” — ${pageModels.length} pages.`, 'ok');
+      startAutosave();
+    } catch (err) { setStatus(err.message, 'err'); }
+  }
+  async function loadBorderStyles() {
+    if (el.border.options.length > 1) return;
+    try { const meta = await (await fetch('/api/meta')).json(); for (const b of meta.borderStyles || []) { const o = document.createElement('option'); o.value = b.id; o.textContent = b.label; el.border.appendChild(o); } } catch (_) { /* */ }
+  }
+  let thumbSeq = 0;
+  // A scaled, non-interactive snapshot of a page. Used for the page rail
+  // (small) and the two-page-spread facing page (full size, with master).
+  function paintPageCanvas(pm, pageIndex, sc, showMaster) {
+    const wrap = document.createElement('div'); wrap.className = 'thumb';
+    wrap.style.width = Math.round(dims.usableWidth * sc) + 'px'; wrap.style.height = Math.round(dims.usableHeight * sc) + 'px';
+    const canvas = document.createElement('div'); canvas.className = 'thumb-canvas';
+    const id = 'thm' + (++thumbSeq); canvas.id = id;
+    canvas.style.width = dims.usableWidth + 'px'; canvas.style.height = dims.usableHeight + 'px'; canvas.style.transform = `scale(${sc})`;
+    const bgv = pageBgCss(pm._bg); if (bgv) canvas.style.background = bgv;
+    if (pm.style) { const st = document.createElement('style'); st.textContent = scopeCss(pm.style, '#' + id); canvas.appendChild(st); }
+    const flow = document.createElement('div'); flow.className = 'pf-flow';
+    if (isMatterPage(pm) && !pm._measured) {
+      // Faithful snapshot of the original matter layout (positions not yet known).
+      flow.style.minHeight = dims.usableHeight + 'px';
+      flow.innerHTML = pm.comps.filter((c) => !c.hidden).map((c) => c.html).join('');
+    } else if (isMatterPage(pm)) {
+      flow.style.minHeight = dims.usableHeight + 'px';
+      pm.comps.forEach((c) => { if (c.hidden) return; const n = document.createElement('div'); n.className = 'pf-piece'; n.innerHTML = c.html; n.style.cssText = `position:absolute;left:${c.baseX}px;top:${c.baseY}px;${c.baseW ? `width:${c.baseW}px;` : ''}transform-origin:top left;`; if (c.dx || c.dy || c.scale !== 1 || c.rot) n.style.transform = `translate(${c.dx}px,${c.dy}px) rotate(${c.rot}deg) scale(${c.scale})`; flow.appendChild(n); });
+    } else {
+      pm.comps.forEach((c) => { if (c.hidden) return; const n = document.createElement('div'); n.className = 'pf-piece'; n.innerHTML = c.html; if (c.dx || c.dy || c.scale !== 1 || c.rot) n.style.transform = `translate(${c.dx}px,${c.dy}px) rotate(${c.rot}deg) scale(${c.scale})`; flow.appendChild(n); });
+    }
+    canvas.appendChild(flow);
+    pm.elements.slice().sort((a, b) => num(a.z, 0) - num(b.z, 0)).forEach((e) => { const n = document.createElement('div'); n.className = 'pf-node'; n.style.transform = `translate(${num(e.x, 0)}px,${num(e.y, 0)}px) rotate(${num(e.rot, 0)}deg) scale(${num(e.scale, 1)})`; n.innerHTML = elHtml(e); canvas.appendChild(n); });
+    // Master overlay (page numbers, headers, frames) — same resolution as export.
+    if (showMaster && master.enabled && master.elements.length && masterAppliesTo(pageIndex)) {
+      const no = masterPageNo(pageIndex);
+      master.elements.slice().sort((a, b) => num(a.z, 0) - num(b.z, 0)).forEach((e) => {
+        const shown = e.field === 'pageNumber' ? { ...e, text: String(no) } : e;
+        const n = document.createElement('div'); n.className = 'pf-node';
+        n.style.transform = `translate(${num(e.x, 0)}px,${num(e.y, 0)}px) rotate(${num(e.rot, 0)}deg) scale(${num(e.scale, 1)})`;
+        n.innerHTML = elHtml(shown); canvas.appendChild(n);
+      });
+    }
+    wrap.appendChild(canvas);
+    return wrap;
+  }
+  const paintThumb = (pm) => paintPageCanvas(pm, pageModels.indexOf(pm), 108 / dims.usableWidth, false);
+  function buildPageList() {
+    el.pageList.innerHTML = '';
+    pageModels.forEach((pm, i) => {
+      const li = document.createElement('li'); li.className = 'page-item';
+      const thumb = paintThumb(pm); thumb.classList.add('page-thumb'); thumb.addEventListener('click', () => selectPage(i));
+      const bar = document.createElement('div'); bar.className = 'page-bar';
+      const lbl = document.createElement('span'); lbl.className = 'page-label'; lbl.textContent = `${i + 1}. ${labelFor(pm)}`;
+      lbl.addEventListener('click', () => selectPage(i));
+      const ops = document.createElement('span'); ops.className = 'page-ops';
+      const mk = (txt, title, fn, cls) => { const b = document.createElement('button'); b.className = 'pageop' + (cls ? ' ' + cls : ''); b.textContent = txt; b.title = title; b.addEventListener('click', (ev) => { ev.stopPropagation(); fn(i); }); return b; };
+      ops.appendChild(mk('↑', 'Move up', (x) => movePage(x, -1)));
+      ops.appendChild(mk('↓', 'Move down', (x) => movePage(x, 1)));
+      ops.appendChild(mk('⧉', 'Duplicate page', duplicatePage));
+      ops.appendChild(mk('✕', 'Delete page', deletePage, 'del'));
+      bar.appendChild(lbl); bar.appendChild(ops);
+      li.appendChild(thumb); li.appendChild(bar); el.pageList.appendChild(li);
+    });
+    highlightPage();
+  }
+  const labelFor = (pm) => pm.name || (pm.blank ? (pm.title && pm.title !== 'Blank' ? pm.title : 'Blank page') : ({ bleedguard: 'Blank (bleed guard)', breather: 'Breather' }[pm.type] || pm.title || pm.type));
+  function highlightPage() {
+    [...el.pageList.children].forEach((li, i) => li.classList.toggle('active', i === cur));
+    const active = el.pageList.children[cur]; if (active && active.scrollIntoView) active.scrollIntoView({ block: 'nearest' });
+  }
+
+  // --- page management ---
+  function movePage(i, dir) {
+    const j = i + dir; if (j < 0 || j >= pageModels.length) return;
+    const t = pageModels[i]; pageModels[i] = pageModels[j]; pageModels[j] = t;
+    if (cur === i) cur = j; else if (cur === j) cur = i;
+    buildPageList(); renderPage();
+  }
+  function deletePage(i) {
+    if (pageModels.length <= 1) { setStatus('A book needs at least one page.', 'err'); return; }
+    pageModels.splice(i, 1);
+    if (cur > i) cur--; else if (cur === i && cur >= pageModels.length) cur = pageModels.length - 1;
+    buildPageList(); renderPage();
+  }
+  function duplicatePage(i) { pageModels.splice(i + 1, 0, clonePageModel(pageModels[i])); cur = i + 1; buildPageList(); renderPage(); }
+  function insertBlankAfterCurrent() { const at = cur < 0 ? pageModels.length : cur + 1; pageModels.splice(at, 0, blankModel()); cur = at; buildPageList(); renderPage(); }
+
+  // --- Ribbon split-button dropdowns (Publisher-style) ---
+  function initDropdowns() {
+    const closeAll = (except) => document.querySelectorAll('.rdrop-menu').forEach((m) => { if (m !== except) { m.hidden = true; const b = m.parentElement.querySelector('.rdrop-btn'); if (b) b.setAttribute('aria-expanded', 'false'); } });
+    // Position a floating menu just under its button, kept on-screen.
+    const place = (btn, menu) => {
+      menu.hidden = false;
+      const r = btn.getBoundingClientRect(); const mw = menu.offsetWidth;
+      const left = Math.max(8, Math.min(r.left, window.innerWidth - mw - 8));
+      menu.style.left = left + 'px'; menu.style.top = (r.bottom + 4) + 'px';
+    };
+    document.querySelectorAll('.rdrop').forEach((drop) => {
+      const btn = drop.querySelector('.rdrop-btn'); const menu = drop.querySelector('.rdrop-menu');
+      if (!btn || !menu) return;
+      btn.addEventListener('click', (e) => { e.stopPropagation(); const open = menu.hidden; closeAll(); if (open) { place(btn, menu); btn.setAttribute('aria-expanded', 'true'); } else { menu.hidden = true; btn.setAttribute('aria-expanded', 'false'); } });
+      // Action items (data-act or .rdrop-item) dismiss the menu; form controls
+      // (checkboxes, colour pickers, selects) inside a menu leave it open.
+      menu.addEventListener('click', (e) => { const it = e.target.closest('[data-act], .rdrop-item'); if (!it) return; menu.hidden = true; btn.setAttribute('aria-expanded', 'false'); if (it.dataset.act) handleDropAct(drop.id, it.dataset.act); });
+    });
+    // A floating menu closes on any click outside a menu (so interacting with a
+    // control inside one keeps it open).
+    document.addEventListener('click', (e) => { if (!e.target.closest('.rdrop-menu')) closeAll(); });
+    window.addEventListener('resize', () => closeAll());
+    // Close when the page scrolls under a floating menu, but NOT when the scroll
+    // happens inside a menu (e.g. spinning the wheel over the Fonts list).
+    document.addEventListener('scroll', (e) => { const t = e.target; if (t && t.closest && t.closest('.rdrop-menu')) return; closeAll(); }, true);
+  }
+  function handleDropAct(dropId, act) {
+    if (dropId === 'pageDrop') {
+      if (act === 'blank') insertBlankAfterCurrent();
+      else if (act === 'dup') { if (cur >= 0) duplicatePage(cur); }
+      else if (act === 'tpl') openTplPicker();
+      else if (act === 'puzzle') openPuzzleInsert();
+    } else if (dropId === 'qrEclDrop') {
+      setQrEcl(act);
+    } else if (dropId === 'qrColorsDrop') {
+      if (act === 'reset') applyQrStyle({ fg: '#000000', bg: '#ffffff' });
+    } else if (dropId === 'alignDrop' || dropId === 'sfAlignDrop' || dropId === 'tlAlignDrop' || dropId === 'picAlignDrop' || dropId === 'qrAlignDrop') {
+      const m = { aleft: 'left', acenter: 'centerh', aright: 'right', atop: 'top', amiddle: 'middle', abottom: 'bottom' };
+      if (m[act]) alignSel(m[act]);
+      else if (act === 'disth') distribute('x');
+      else if (act === 'distv') distribute('y');
+    } else if (dropId === 'rotateDrop' || dropId === 'sfRotateDrop' || dropId === 'tlRotateDrop' || dropId === 'picRotateDrop') {
+      if (act === 'rright') rotateBy(90);
+      else if (act === 'rleft') rotateBy(-90);
+      else if (act === 'flipv') flip('v');
+      else if (act === 'fliph') flip('h');
+      else if (act === 'free') freeRotate();
+    } else if (dropId === 'wrapDrop' || dropId === 'sfWrapDrop' || dropId === 'tlWrapDrop' || dropId === 'picWrapDrop') {
+      if (act === 'wfront') reorder('front');
+      else if (act === 'wbehind') reorder('back');
+    } else if (dropId === 'sfEffectsDrop') {
+      shapeEffects(act);
+    } else if (dropId === 'picEffectsDrop') {
+      picEffects(act);
+    } else if (dropId === 'picCaptionDrop') {
+      picCaption(act);
+    } else if (dropId === 'picCompressDrop') {
+      const m = { ppi300: 300, ppi220: 220, ppi150: 150, ppi96: 96 };
+      if (m[act] != null) compressSel(m[act], el.picCompressCrop ? el.picCompressCrop.checked : true);
+    } else if (dropId === 'tdBordersDrop') {
+      const m = { all: 1, thin: 0.5, thick: 2, none: 0 }; if (m[act] != null) tblSet('borderW', m[act]);
+    } else if (dropId === 'tlDeleteDrop') {
+      if (act === 'row') tblDelRow(); else if (act === 'col') tblDelCol();
+    } else if (dropId === 'tlMarginsDrop') {
+      const m = { none: 0, narrow: 3, moderate: 6, wide: 12 }; if (m[act] != null) tblSet('cellPad', m[act]);
+    } else if (dropId === 'pageNoDrop') {
+      insertPageNumber(act);
+    } else if (dropId === 'accentDrop') {
+      addAccentBar(act);
+    } else if (dropId === 'guidesDrop') {
+      if (act === 'addh') addGuide('h');
+      else if (act === 'addv') addGuide('v');
+      else if (act === 'clear') clearGuides();
+    } else if (dropId === 'marginsDrop') {
+      if (act === 'fit') fitToMargins(false); else setMargins(act);
+    } else if (dropId === 'bgDrop') {
+      setBgType(act);
+    } else if (dropId === 'fmtArrangeDrop') {
+      const orders = { ofront: 'front', oforward: 'forward', obackward: 'backward', oback: 'back' };
+      if (orders[act]) reorder(orders[act]);
+      else if (act === 'rright') rotateBy(90);
+      else if (act === 'rleft') rotateBy(-90);
+      else if (act === 'fliph') flip('h');
+      else if (act === 'flipv') flip('v');
+      else if (act === 'disth') distribute('x');
+      else if (act === 'distv') distribute('y');
+    } else if (dropId === 'tbDirDrop') {
+      const o = selText(); if (o) { pushUndo(); o.rot = act === 'd90' ? 90 : act === 'd270' ? 270 : 0; applyElTf(o); drawSel(); syncSelUI(); }
+    } else if (dropId === 'tbFitDrop') {
+      applyTextFit(act);
+    } else if (dropId === 'tbColsDrop') {
+      applyTextPropU('columns', Number(act) || 1);
+    } else if (dropId === 'tbMarginsDrop') {
+      setTextMargins(act);
+    } else if (dropId === 'tbDropCapDrop') {
+      applyTextPropU('dropCap', Number(act) || 0);
+    } else if (dropId === 'tbNumDrop') {
+      applyTextPropU('numStyle', act === 'default' ? undefined : act);
+    } else if (dropId === 'tbLigDrop') {
+      applyTextPropU('ligatures', act === 'standard' ? undefined : act);
+    } else if (dropId === 'tbStyDrop') {
+      const o = selText(); if (!o) return; pushUndo();
+      if (/^ss\d$/.test(act)) o.stySet = Number(act.slice(2)) || undefined;
+      else if (act === 'swash') o.swash = !o.swash;
+      else if (act === 'salt') o.styAlt = !o.styAlt;
+      else if (act === 'calt') { if (o.contextual === false) delete o.contextual; else o.contextual = false; }
+      o._node.innerHTML = elHtml(o); drawSel(); syncFontUI(o);
+    } else if (dropId === 'tbEffectsDrop') {
+      const o = selText(); if (!o) return; pushUndo();
+      if (act === 'shadow') { if (o.textShadow) delete o.textShadow; else o.textShadow = '#00000040'; }
+      else if (act === 'none') { delete o.textStroke; delete o.textStrokeW; delete o.textShadow; }
+      o._node.innerHTML = elHtml(o); drawSel();
+    }
+  }
+
+  // --- page templates -------------------------------------------------------
+  // Matter and layout pages live in the editor as templates: inserting one
+  // drops a fresh page whose content is ordinary, editable text/shape objects.
+  const tEl = (o) => ({ group: 'el', kind: 'text', scale: 1, rot: 0, z: 100, color: '#222222', align: 'left', fontSize: 24, w: 240, ...o });
+  const sEl = (o) => ({ group: 'el', kind: 'shape', scale: 1, rot: 0, z: 90, fill: 'none', stroke: '#222222', strokeW: 2, ...o });
+  const R = Math.round;
+  const BUILTIN_TPLS = [
+    { id: 'title', name: 'Title Page', desc: 'Book title, subtitle & author', make: (c) => {
+      const big = Math.max(34, R(c.W / 7)); const y0 = R(c.H * 0.3);
+      const els = [tEl({ text: c.title || 'Book Title', x: 0, y: y0, w: c.W, fontSize: big, align: 'center', bold: true })];
+      let ay = y0 + R(big * 1.5);
+      if (c.subtitle) { els.push(tEl({ text: c.subtitle, x: R(c.W * 0.1), y: ay, w: R(c.W * 0.8), fontSize: Math.max(16, R(c.W / 24)), align: 'center', color: '#333333' })); ay += R(c.W / 16); }
+      els.push(tEl({ text: c.author ? `by ${c.author}` : 'by Your Name', x: 0, y: R(c.H * 0.62), w: c.W, fontSize: Math.max(16, R(c.W / 26)), align: 'center' }));
+      return els;
+    } },
+    { id: 'copyright', name: 'Copyright', desc: 'Legal boilerplate, bottom of page', make: (c) => {
+      const fs = Math.max(11, R(c.W / 46)); const x = R(c.W * 0.08), w = R(c.W * 0.84), y0 = R(c.H * 0.72);
+      return [
+        tEl({ text: `Copyright © ${c.year} ${c.author || c.title || 'Your Name'}`, x, y: y0, w, fontSize: fs }),
+        tEl({ text: 'All rights reserved.', x, y: y0 + R(fs * 1.8), w, fontSize: fs }),
+        tEl({ text: 'No part of this publication may be reproduced, distributed, or transmitted in any form or by any means without the prior written permission of the publisher, except for brief quotations in reviews.', x, y: y0 + R(fs * 3.8), w, fontSize: Math.max(9, R(fs * 0.86)), color: '#555555' }),
+      ];
+    } },
+    { id: 'belongsTo', name: 'This Book Belongs To', desc: 'Kids ownership page, centered', make: (c) => {
+      const fs = Math.max(20, R(c.W / 16));
+      return [
+        tEl({ text: 'This Book Belongs To', x: 0, y: R(c.H * 0.32), w: c.W, fontSize: fs, align: 'center', bold: true }),
+        sEl({ shape: 'line', x: R(c.W * 0.15), y: R(c.H * 0.46), w: R(c.W * 0.7), h: 6, stroke: '#000000', strokeW: 3, fill: 'none' }),
+        tEl({ text: '★ ★ ★', x: 0, y: R(c.H * 0.54), w: c.W, fontSize: R(fs * 0.9), align: 'center' }),
+      ];
+    } },
+    { id: 'intro', name: 'Introduction / Welcome', desc: 'Heading + a welcome paragraph', make: (c) => {
+      const h = Math.max(22, R(c.W / 14)); const x = R(c.W * 0.08), w = R(c.W * 0.84), y0 = R(c.H * 0.14);
+      return [
+        tEl({ text: 'Welcome!', x, y: y0, w, fontSize: h, bold: true }),
+        tEl({ text: 'Grab a pencil and get ready for hours of fun. Take your time — and if you get stuck, the answers are in the back. Happy puzzling!', x, y: y0 + R(h * 1.8), w, fontSize: Math.max(13, R(c.W / 40)) }),
+      ];
+    } },
+    { id: 'about', name: 'About the Author', desc: 'Heading + short bio', make: (c) => {
+      const h = Math.max(20, R(c.W / 15)); const y0 = R(c.H * 0.12);
+      return [
+        tEl({ text: 'About the Author', x: 0, y: y0, w: c.W, fontSize: h, align: 'center', bold: true }),
+        tEl({ text: `${c.author || 'Your name'} makes puzzle and activity books for all ages. Write a short, friendly bio here.`, x: R(c.W * 0.12), y: y0 + R(h * 2), w: R(c.W * 0.76), fontSize: Math.max(13, R(c.W / 40)), align: 'center' }),
+      ];
+    } },
+    { id: 'morebooks', name: 'More Books', desc: 'Cross-promo list page', make: (c) => {
+      const h = Math.max(20, R(c.W / 15)); const y0 = R(c.H * 0.14);
+      return [
+        tEl({ text: "More Books You'll Love", x: 0, y: y0, w: c.W, fontSize: h, align: 'center', bold: true }),
+        tEl({ text: '•  Title One\n•  Title Two\n•  Title Three', x: 0, y: y0 + R(h * 2.2), w: c.W, fontSize: Math.max(14, R(c.W / 34)), align: 'center' }),
+      ];
+    } },
+    { id: 'section', name: 'Section Divider', desc: 'Big centered chapter title', make: (c) => (
+      [tEl({ text: 'Chapter One', x: 0, y: R(c.H * 0.44), w: c.W, fontSize: Math.max(30, R(c.W / 9)), align: 'center', bold: true })]
+    ) },
+  ];
+
+  // Building Blocks: pre-designed clusters of objects (heading / pull quote /
+  // sidebar) dropped onto the CURRENT page as a movable group. `c` carries the
+  // page size and scheme colors.
+  const PAGE_PARTS = [
+    { cat: 'Headings', name: 'Heading + rule', make: (c) => {
+      const w = R(c.W * 0.8), x = R(c.W * 0.1), y = R(c.H * 0.12);
+      return [
+        tEl({ text: 'Heading', x, y, w, fontSize: Math.max(28, R(c.W / 16)), bold: true, color: c.color }),
+        sEl({ shape: 'line', x, y: y + R(c.W / 12), w, h: 12, fill: 'none', stroke: c.stroke, strokeW: 3 }),
+      ];
+    } },
+    { cat: 'Headings', name: 'Bar heading', make: (c) => {
+      const w = R(c.W * 0.8), x = R(c.W * 0.1), y = R(c.H * 0.12), h = R(c.W / 9);
+      return [
+        sEl({ shape: 'rect', x, y, w, h, fill: c.fill, stroke: 'none', strokeW: 0, z: 90 }),
+        tEl({ text: 'Heading', x: x + 16, y: y + R(h * 0.24), w: w - 32, fontSize: Math.max(22, R(c.W / 18)), bold: true, color: '#ffffff', z: 100 }),
+      ];
+    } },
+    { cat: 'Pull Quotes', name: 'Lined quote', make: (c) => {
+      const w = R(c.W * 0.6), x = R(c.W * 0.2), y = R(c.H * 0.2), fs = Math.max(18, R(c.W / 26));
+      return [
+        sEl({ shape: 'line', x, y, w, h: 12, fill: 'none', stroke: c.stroke, strokeW: 2 }),
+        tEl({ text: '“A short, punchy line to draw the reader in.”', x, y: y + 18, w, fontSize: fs, italic: true, align: 'center', color: c.color }),
+        sEl({ shape: 'line', x, y: y + 18 + R(c.W / 8), w, h: 12, fill: 'none', stroke: c.stroke, strokeW: 2 }),
+      ];
+    } },
+    { cat: 'Pull Quotes', name: 'Boxed quote', make: (c) => {
+      const w = R(c.W * 0.6), x = R(c.W * 0.2), y = R(c.H * 0.2), h = R(c.W / 4);
+      return [
+        sEl({ shape: 'rect', x, y, w, h, fill: 'none', stroke: c.stroke, strokeW: 2, z: 90 }),
+        tEl({ text: '“Wrap a memorable line in a clean box.”', x: x + 18, y: y + R(h * 0.32), w: w - 36, fontSize: Math.max(18, R(c.W / 26)), italic: true, align: 'center', color: c.color, z: 100 }),
+      ];
+    } },
+    { cat: 'Sidebars', name: 'Color sidebar', make: (c) => {
+      const w = R(c.W * 0.32), x = R(c.W * 0.62), y = R(c.H * 0.12), h = R(c.H * 0.5);
+      return [
+        sEl({ shape: 'rect', x, y, w, h, fill: c.fill, stroke: 'none', strokeW: 0, z: 90 }),
+        tEl({ text: 'Did you know?', x: x + 14, y: y + 16, w: w - 28, fontSize: Math.max(16, R(c.W / 28)), bold: true, color: '#ffffff', z: 100 }),
+        tEl({ text: 'Add a fun fact or tip here.', x: x + 14, y: y + 16 + R(c.W / 7), w: w - 28, fontSize: Math.max(13, R(c.W / 36)), color: '#ffffff', z: 100 }),
+      ];
+    } },
+    { cat: 'Sidebars', name: 'Bordered sidebar', make: (c) => {
+      const w = R(c.W * 0.32), x = R(c.W * 0.62), y = R(c.H * 0.12), h = R(c.H * 0.5);
+      return [
+        sEl({ shape: 'rect', x, y, w, h, fill: 'none', stroke: c.stroke, strokeW: 2, z: 90 }),
+        tEl({ text: 'Notes', x: x + 14, y: y + 16, w: w - 28, fontSize: Math.max(16, R(c.W / 28)), bold: true, color: c.color, z: 100 }),
+        tEl({ text: 'Jot a note or a short list here.', x: x + 14, y: y + 16 + R(c.W / 7), w: w - 28, fontSize: Math.max(13, R(c.W / 36)), color: c.color, z: 100 }),
+      ];
+    } },
+  ];
+  function insertPagePart(part) {
+    if (el.main.hidden || !part) return;
+    pushUndo();
+    const c = { W: dims.usableWidth, H: dims.usableHeight, fill: schemeFill(), stroke: schemeStroke(), color: '#222222' };
+    const els = part.make(c).map((e) => ({ ...e, group: 'el', id: uid++ }));
+    const gid = els.length > 1 ? 'g' + uid++ : null;
+    const pm = curModel();
+    els.forEach((e) => { if (gid) e.gid = gid; pm.elements.push(e); el.stageInner.insertBefore(makeEl(e), selLayer); });
+    setSel(els);
+    setStatus(`Inserted “${part.name}”.`, 'ok');
+  }
+  function buildPagePartsMenu() {
+    const host = document.getElementById('pagePartsMenu'); if (!host) return;
+    host.innerHTML = '';
+    const byCat = {};
+    PAGE_PARTS.forEach((part) => { (byCat[part.cat] = byCat[part.cat] || []).push(part); });
+    Object.keys(byCat).forEach((cat) => {
+      const h = document.createElement('div'); h.className = 'shapegal-cat'; h.textContent = cat; host.appendChild(h);
+      byCat[cat].forEach((part) => {
+        const btn = document.createElement('button'); btn.type = 'button'; btn.textContent = part.name;
+        btn.addEventListener('click', () => { closeObjMenus(); insertPagePart(part); });
+        host.appendChild(btn);
+      });
+    });
+  }
+
+  function openTplPicker() { if (el.main.hidden) return; renderTplPicker(); el.tplModal.hidden = false; }
+  function closeTplPicker() { el.tplModal.hidden = true; }
+  function tplCard(name, desc, onPick, onDelete) {
+    const card = document.createElement('div'); card.className = 'pf-tpl-card';
+    const pick = document.createElement('button'); pick.className = 'pf-tpl-pick';
+    pick.innerHTML = `<span class="pf-tpl-name">${escHtml(name)}</span><span class="pf-tpl-desc">${escHtml(desc)}</span>`;
+    pick.addEventListener('click', onPick); card.appendChild(pick);
+    if (onDelete) { const d = document.createElement('button'); d.className = 'pf-tpl-del'; d.textContent = '✕'; d.title = 'Delete template'; d.addEventListener('click', (e) => { e.stopPropagation(); onDelete(); }); card.appendChild(d); }
+    return card;
+  }
+  function renderTplPicker() {
+    el.tplBuiltin.innerHTML = '';
+    BUILTIN_TPLS.forEach((t) => el.tplBuiltin.appendChild(tplCard(t.name, t.desc, () => { insertBuiltinTpl(t); closeTplPicker(); })));
+    const saved = loadSavedTemplates();
+    el.tplSaved.innerHTML = '';
+    el.tplSavedEmpty.hidden = saved.length > 0;
+    el.tplSavedCount.textContent = saved.length ? `(${saved.length})` : '';
+    saved.forEach((t) => el.tplSaved.appendChild(tplCard(
+      t.name, `${t.elements.length} object${t.elements.length !== 1 ? 's' : ''}`,
+      () => { insertSavedTpl(t); closeTplPicker(); },
+      () => { deleteSavedTemplate(t.id); renderTplPicker(); }
+    )));
+  }
+  function insertBuiltinTpl(t) {
+    const ctx = { W: dims.usableWidth, H: dims.usableHeight, title: (bookConfig && bookConfig.title) || '', subtitle: (bookConfig && bookConfig.subtitle) || '', author: (bookConfig && bookConfig.author) || '', year: new Date().getFullYear() };
+    insertPageWithEls(t.make(ctx).map((e) => ({ ...e, id: uid++ })), t.name);
+  }
+  function insertSavedTpl(t) {
+    const sx = dims.usableWidth / (t.refW || dims.usableWidth), sy = dims.usableHeight / (t.refH || dims.usableHeight);
+    insertPageWithEls((t.elements || []).map((e) => scaleEl(e, sx, sy)), t.name);
+  }
+  function scaleEl(e, sx, sy) {
+    const { _node, ...r } = e; const o = { ...r, group: 'el', id: uid++ };
+    o.x = R(num(e.x, 0) * sx); o.y = R(num(e.y, 0) * sy);
+    if (e.kind === 'text') { if (e.w != null) o.w = R(num(e.w, 240) * sx); if (e.fontSize != null) o.fontSize = Math.max(6, R(num(e.fontSize, 24) * sx)); }
+    else if (e.kind === 'image') { if (e.width != null) o.width = R(num(e.width, 160) * sx); }
+    else if (e.kind === 'shape') { if (e.w != null) o.w = R(num(e.w, 160) * sx); if (e.h != null) o.h = R(num(e.h, 120) * sy); }
+    return o;
+  }
+  function insertPageWithEls(els, name) {
+    const m = blankModel(); m.title = name || 'Template'; m.elements = els;
+    const at = cur < 0 ? pageModels.length : cur + 1;
+    pageModels.splice(at, 0, m); cur = at; buildPageList(); renderPage();
+    setStatus(`Inserted “${name}”.`, 'ok');
+  }
+
+  // --- Change Template: apply a layout to the CURRENT page (with previews) ---
+  function tplCtx() {
+    return { W: dims.usableWidth, H: dims.usableHeight, title: (bookConfig && bookConfig.title) || '',
+      subtitle: (bookConfig && bookConfig.subtitle) || '', author: (bookConfig && bookConfig.author) || '',
+      year: new Date().getFullYear(), fill: schemeFill(), stroke: schemeStroke(), color: '#222222' };
+  }
+  // Element list for a template, already scaled to the current page.
+  function tplEls(t) {
+    if (t.make) return t.make(tplCtx()).map((e) => ({ ...e, id: uid++ }));
+    const sx = dims.usableWidth / (t.refW || dims.usableWidth), sy = dims.usableHeight / (t.refH || dims.usableHeight);
+    return (t.elements || []).map((e) => scaleEl(e, sx, sy));
+  }
+  // A small non-interactive visual preview of a template's elements.
+  function tplThumb(els, refW, refH) {
+    const W = 138, s = W / (refW || dims.usableWidth), H = Math.round((refH || dims.usableHeight) * s);
+    const box = document.createElement('div'); box.className = 'pf-tplchg-thumb';
+    box.style.width = W + 'px'; box.style.height = H + 'px';
+    const inner = document.createElement('div');
+    inner.style.cssText = `position:absolute;top:0;left:0;width:${refW}px;height:${refH}px;transform:scale(${s});transform-origin:top left;`;
+    (els || []).forEach((e) => {
+      const d = document.createElement('div'); d.style.position = 'absolute';
+      d.style.left = num(e.x, 0) + 'px'; d.style.top = num(e.y, 0) + 'px';
+      if (e.kind === 'text') {
+        d.style.width = num(e.w, 240) + 'px'; d.style.fontSize = Math.max(6, num(e.fontSize, 24)) + 'px';
+        d.style.color = e.color || '#222'; d.style.textAlign = e.align || 'left';
+        d.style.fontWeight = e.bold ? '700' : '400'; d.style.fontStyle = e.italic ? 'italic' : 'normal';
+        d.style.lineHeight = '1.15'; d.style.overflow = 'hidden';
+        d.textContent = String(e.text || '').slice(0, 120);
+      } else if (e.kind === 'shape' && e.shape === 'line') {
+        d.style.width = num(e.w, 120) + 'px'; d.style.borderTop = `${Math.max(1, num(e.strokeW, 2))}px solid ${e.stroke || '#222'}`;
+      } else if (e.kind === 'shape') {
+        d.style.width = num(e.w, 120) + 'px'; d.style.height = num(e.h, 80) + 'px';
+        if (e.fill && e.fill !== 'none') d.style.background = e.fill;
+        if (e.stroke && e.stroke !== 'none') d.style.border = `${Math.max(1, num(e.strokeW, 2))}px solid ${e.stroke}`;
+      } else if (e.kind === 'image') {
+        d.style.width = num(e.width, 160) + 'px'; d.style.height = num(e.width, 160) * 0.66 + 'px';
+        d.style.background = '#e7ebf5'; d.style.border = '1px dashed #b7c0d8';
+      } else return;
+      inner.appendChild(d);
+    });
+    box.appendChild(inner); return box;
+  }
+  function changeTplCard(name, desc, els, refW, refH, onPick, onDelete) {
+    const card = document.createElement('button'); card.type = 'button'; card.className = 'pf-tplchg-card';
+    card.appendChild(tplThumb(els, refW, refH));
+    const n = document.createElement('span'); n.className = 'pf-tplchg-name'; n.textContent = name; card.appendChild(n);
+    if (desc) { const dd = document.createElement('span'); dd.className = 'pf-tplchg-desc'; dd.textContent = desc; card.appendChild(dd); }
+    card.addEventListener('click', onPick);
+    if (onDelete) { const del = document.createElement('span'); del.className = 'pf-tplchg-del'; del.textContent = '✕'; del.title = 'Delete template';
+      del.addEventListener('click', (e) => { e.stopPropagation(); onDelete(); }); card.appendChild(del); }
+    return card;
+  }
+  function openChangeTpl() { if (el.main.hidden) { setStatus('Open a book first.', ''); return; } renderChangeTpl(); el.changeTplModal.hidden = false; }
+  function closeChangeTpl() { el.changeTplModal.hidden = true; }
+  function renderChangeTpl() {
+    const pm = curModel();
+    el.changeTplPageName.textContent = (pm && pm.title) ? `“${pm.title}”` : 'this page';
+    el.changeTplBuiltin.innerHTML = '';
+    BUILTIN_TPLS.forEach((t) => {
+      const els = t.make(tplCtx());
+      el.changeTplBuiltin.appendChild(changeTplCard(t.name, t.desc, els, dims.usableWidth, dims.usableHeight,
+        () => { applyTplToPage(t); closeChangeTpl(); }));
+    });
+    const saved = loadSavedTemplates();
+    el.changeTplSaved.innerHTML = '';
+    el.changeTplSavedEmpty.hidden = saved.length > 0;
+    el.changeTplSavedCount.textContent = saved.length ? `(${saved.length})` : '';
+    saved.forEach((t) => el.changeTplSaved.appendChild(changeTplCard(
+      t.name, `${t.elements.length} object${t.elements.length !== 1 ? 's' : ''}`, t.elements, t.refW, t.refH,
+      () => { applyTplToPage(t); closeChangeTpl(); },
+      () => { deleteSavedTemplate(t.id); renderChangeTpl(); }
+    )));
+  }
+  function applyTplToPage(t) {
+    const pm = curModel(); if (!pm) return;
+    const had = (pm.elements && pm.elements.length) || 0;
+    if (had && !window.confirm(`Replace this page's ${had} object${had !== 1 ? 's' : ''} with the “${t.name}” layout?`)) return;
+    pushUndo();
+    pm.elements = tplEls(t);
+    pm.title = pm.title && pm.title !== 'Blank' ? pm.title : t.name;
+    renderPage(); buildPageList();
+    setStatus(`Applied “${t.name}” to this page.`, 'ok');
+  }
+
+  // --- Fonts: built-in stacks + uploaded custom fonts ------------------------
+  // Values mirror the FONTS map in engine/element-html.js so a font renders the
+  // same on screen and in the exported PDF. Custom fonts use `custom:<id>`.
+  const FONT_LIST = [
+    { v: 'sans', label: 'Sans (Arial)' }, { v: 'serif', label: 'Serif (Georgia)' },
+    { v: 'rounded', label: 'Rounded (Verdana)' }, { v: 'trebuchet', label: 'Trebuchet MS' },
+    { v: 'tahoma', label: 'Tahoma' }, { v: 'century', label: 'Century Gothic' },
+    { v: 'palatino', label: 'Palatino' }, { v: 'garamond', label: 'Garamond' },
+    { v: 'mono', label: 'Mono (Courier)' }, { v: 'hand', label: 'Handwritten' },
+    { v: 'brush', label: 'Brush Script' }, { v: 'impact', label: 'Impact' },
+  ];
+  const FONT_MIME = { ttf: 'font/ttf', otf: 'font/otf', woff: 'font/woff', woff2: 'font/woff2' };
+  function loadCustomFonts() { try { return JSON.parse(localStorage.getItem('pf_fonts') || '[]'); } catch (_) { return []; } }
+  function saveCustomFonts(l) { try { localStorage.setItem('pf_fonts', JSON.stringify(l)); return true; } catch (_) { setStatus('Could not save the font — browser storage is full.', 'err'); return false; } }
+  function fontSlug(name) { return String(name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32); }
+  // Custom fonts formatted for the shared @font-face builder / PDF send.
+  function customFontsForSend() { return loadCustomFonts().map((f) => ({ family: 'pf-custom-' + f.id, dataUrl: f.dataUrl })); }
+  // Only the custom fonts actually used by a text object anywhere in the book —
+  // keeps export payloads lean (font data URLs are large).
+  function usedCustomFontsForSend() {
+    const used = new Set();
+    pageModels.forEach((pm) => (pm.elements || []).forEach((e) => { if (e.kind === 'text' && String(e.fontFamily || '').slice(0, 7) === 'custom:') used.add(e.fontFamily.slice(7)); }));
+    return loadCustomFonts().filter((f) => used.has(f.id)).map((f) => ({ family: 'pf-custom-' + f.id, dataUrl: f.dataUrl }));
+  }
+  // Keep a <style> in <head> with @font-face rules for every uploaded font so
+  // the live editor renders them (the PDF export gets the same rules server-side).
+  function injectCustomFontFaces() {
+    let st = document.getElementById('pf-custom-fonts');
+    if (!st) { st = document.createElement('style'); st.id = 'pf-custom-fonts'; document.head.appendChild(st); }
+    st.textContent = (window.PFElements && PFElements.fontFaceCss) ? PFElements.fontFaceCss(customFontsForSend()) : '';
+  }
+  function fontOptionsHtml() {
+    let opts = FONT_LIST.map((f) => `<option value="${f.v}">${escHtml(f.label)}</option>`).join('');
+    const custom = loadCustomFonts();
+    if (custom.length) opts += `<optgroup label="Your fonts">${custom.map((f) => `<option value="custom:${escHtml(f.id)}">${escHtml(f.name)}</option>`).join('')}</optgroup>`;
+    return opts;
+  }
+  function refreshFontSelects() {
+    if (el.fontFamily) { const c = el.fontFamily.value; el.fontFamily.innerHTML = fontOptionsHtml(); if (c) el.fontFamily.value = c; }
+    buildFontsMenu();
+  }
+  const fontStackFor = (v) => (window.PFElements && PFElements.fontStack) ? PFElements.fontStack(v) : 'inherit';
+  // Publisher-style Fonts gallery: each row previews the font in itself and
+  // applies it as the page font. Custom uploads sit under "Your fonts" with a
+  // remove button; the Upload control lives in the menu footer (in the HTML).
+  function buildFontsMenu() {
+    const host = document.getElementById('fontsList'); if (!host) return;
+    host.innerHTML = '';
+    const cur = (curModel() && curModel()._font) || '';
+    const addRow = (value, label, stack, onDel) => {
+      const row = document.createElement('div'); row.className = 'font-row' + (value === cur ? ' on' : '');
+      const use = document.createElement('button'); use.type = 'button'; use.className = 'font-row-use rdrop-item';
+      use.innerHTML = `<span class="font-row-aa">Aa</span><span class="font-row-name">${escHtml(label)}</span>`;
+      use.style.fontFamily = stack;
+      use.addEventListener('click', () => applyPageFont(value));
+      row.appendChild(use);
+      if (onDel) { const del = document.createElement('button'); del.type = 'button'; del.className = 'font-menu-del'; del.textContent = '✕'; del.title = 'Remove font'; del.addEventListener('click', (e) => { e.stopPropagation(); onDel(); }); row.appendChild(del); }
+      host.appendChild(row);
+    };
+    FONT_LIST.forEach((f) => addRow(f.v, f.label, fontStackFor(f.v)));
+    const custom = loadCustomFonts();
+    if (custom.length) {
+      const cat = document.createElement('div'); cat.className = 'font-cat'; cat.textContent = 'Your fonts'; host.appendChild(cat);
+      custom.forEach((f) => addRow('custom:' + f.id, f.name, `'pf-custom-${f.id}', sans-serif`, () => removeCustomFont(f.id)));
+    }
+  }
+  function onFontUpload(input) {
+    const file = input && input.files && input.files[0]; if (!file) return;
+    const ext = (file.name.split('.').pop() || '').toLowerCase();
+    if (!FONT_MIME[ext]) { setStatus('Pick a .ttf, .otf, .woff, or .woff2 font file.', 'err'); input.value = ''; return; }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const b64 = String(reader.result || '').split(',')[1] || '';
+      if (!b64) { setStatus('Could not read that font file.', 'err'); return; }
+      const dataUrl = `data:${FONT_MIME[ext]};base64,${b64}`;
+      const name = file.name.replace(/\.[^.]+$/, '');
+      const list = loadCustomFonts();
+      let id = fontSlug(name) || ('f' + Date.now().toString(36));
+      while (list.some((f) => f.id === id)) id += '-2';
+      list.push({ id, name, dataUrl });
+      if (!saveCustomFonts(list)) return;
+      injectCustomFontFaces(); refreshFontSelects();
+      applyPageFont('custom:' + id);
+      setStatus(`Added font “${name}”.`, 'ok');
+    };
+    reader.onerror = () => setStatus('Could not read that font file.', 'err');
+    reader.readAsDataURL(file); input.value = '';
+  }
+  function removeCustomFont(id) {
+    saveCustomFonts(loadCustomFonts().filter((f) => f.id !== id));
+    injectCustomFontFaces(); refreshFontSelects();
+    setStatus('Removed font.', 'ok');
+  }
+  // Set the default font for every text object on the current page.
+  function applyPageFont(v) {
+    if (!v) return;
+    const pm = curModel(); if (!pm) return;
+    pushUndo();
+    pm._font = v;
+    (pm.elements || []).forEach((e) => { if (e.kind === 'text') e.fontFamily = v; });
+    renderPage(); buildFontsMenu();
+    const label = v.slice(0, 7) === 'custom:' ? (loadCustomFonts().find((f) => 'custom:' + f.id === v) || {}).name || 'custom' : (FONT_LIST.find((f) => f.v === v) || {}).label || v;
+    setStatus(`Page font set to ${label}.`, 'ok');
+  }
+
+  // --- Insert a freshly generated puzzle page ---
+  const PUZ_LABELS = { wordsearch: 'Word Search', numbersearch: 'Number Search', sudoku: 'Sudoku', maze: 'Maze', cryptogram: 'Cryptogram', wordscramble: 'Word Scramble', crossword: 'Crossword', krisskross: 'Kriss-Kross', nonogram: 'Nonogram', trivia: 'Trivia', logicgrid: 'Logic Grid', wordladder: 'Word Ladder', wordwheel: 'Word Wheel', cipher: 'Cipher', coloring: 'Coloring', drawing: 'Drawing' };
+  let puzTypesLoaded = false;
+  let insertMeta = null;
+  const ACTIVITY_TYPES = new Set(['coloring', 'drawing']);
+  async function loadPuzzleTypes() {
+    if (puzTypesLoaded || !el.puzType) return;
+    try {
+      insertMeta = await (await fetch('/api/meta')).json();
+      // bleedguard = the blank filler (its own menu item); breather = an
+      // auto-inserted kids rest page. Neither is a user-selectable page.
+      const HIDDEN = new Set(['bleedguard', 'breather']);
+      (insertMeta.types || []).forEach((t) => {
+        const id = typeof t === 'string' ? t : t.id;
+        if (HIDDEN.has(id)) return;
+        const label = (typeof t === 'object' && t.label) || PUZ_LABELS[id] || id;
+        const o = document.createElement('option'); o.value = id; o.textContent = label; el.puzType.appendChild(o);
+      });
+      const ws = [...el.puzType.options].find((o) => o.value === 'wordsearch'); if (ws) el.puzType.value = 'wordsearch';
+      fillThemeSelect(el.puzTheme, insertMeta.themes || [], '— book theme —');
+      puzTypesLoaded = el.puzType.options.length > 0;
+    } catch (_) { /* leave empty; insert will warn */ }
+  }
+  // Difficulty labels track the audience (kids ages vs adult Easy–Expert).
+  function fillPuzDiffOptions() {
+    const kids = String(el.puzAudience.value).toLowerCase() === 'kids';
+    const list = (insertMeta && insertMeta.difficulty && (kids ? insertMeta.difficulty.kids : insertMeta.difficulty.adult)) || [];
+    const prev = el.puzDiff.value;
+    el.puzDiff.innerHTML = '';
+    (list.length ? list : [{ value: 1, label: 'Easy' }, { value: 2, label: 'Medium' }, { value: 3, label: 'Hard' }, { value: 4, label: 'Expert' }])
+      .forEach((o) => { const opt = document.createElement('option'); opt.value = String(o.value); opt.textContent = kids && o.ages ? `${o.label} (${o.ages})` : o.label; el.puzDiff.appendChild(opt); });
+    if ([...el.puzDiff.options].some((o) => o.value === prev)) el.puzDiff.value = prev;
+  }
+  // Coloring pages take a style, not a difficulty — show the right control.
+  function syncPuzTypeUI() {
+    const isColor = el.puzType.value === 'coloring';
+    if (el.puzColorRow) el.puzColorRow.hidden = !isColor;
+  }
+  // Grouped theme picker (mirrors the Book Builder). Blank option = book theme.
+  function fillThemeSelect(select, themeList, defaultLabel) {
+    if (!select) return;
+    select.innerHTML = '';
+    if (defaultLabel) { const o = document.createElement('option'); o.value = ''; o.textContent = defaultLabel; select.appendChild(o); }
+    const byCat = {};
+    (themeList || []).forEach((th) => { (byCat[th.category] = byCat[th.category] || []).push(th); });
+    Object.keys(byCat).sort().forEach((cat) => {
+      const group = document.createElement('optgroup'); group.label = cat;
+      byCat[cat].forEach((th) => { const o = document.createElement('option'); o.value = th.id; o.textContent = `${th.label} (${th.wordCount})`; group.appendChild(o); });
+      select.appendChild(group);
+    });
+  }
+  async function openPuzzleInsert() {
+    if (el.main.hidden) { setStatus('Open a book first.', ''); return; }
+    await loadPuzzleTypes();
+    // Default the audience to the book's, then fill difficulty to match.
+    el.puzAudience.value = (bookConfig && bookConfig.audience) === 'adult' ? 'adult' : 'kids';
+    fillPuzDiffOptions();
+    const d0 = bookConfig && bookConfig.puzzles && bookConfig.puzzles[0] && bookConfig.puzzles[0].difficulty;
+    if (d0 && [...el.puzDiff.options].some((o) => o.value === String(d0))) el.puzDiff.value = String(d0);
+    syncPuzTypeUI();
+    el.puzStatus.textContent = ''; el.puzModal.hidden = false;
+  }
+  function closePuzzleInsert() { el.puzModal.hidden = true; }
+  async function insertPuzzlePages() {
+    const type = el.puzType.value;
+    const difficulty = Number(el.puzDiff.value) || 1;
+    const count = Math.max(1, Math.min(50, Number(el.puzCount.value) || 1));
+    const audience = el.puzAudience.value === 'adult' ? 'adult' : 'kids';
+    const style = (type === 'coloring' && el.puzColorStyle && el.puzColorStyle.value) || undefined;
+    if (!type) { el.puzStatus.textContent = 'Pick a puzzle type.'; return; }
+    el.puzStatus.textContent = 'Generating…'; el.puzInsert.disabled = true;
+    try {
+      const res = await fetch('/api/book/insert-puzzle', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config: bookConfig, type, difficulty, count, audience, style, theme: (el.puzTheme && el.puzTheme.value) || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Could not generate the puzzle.');
+      const pages = data.pages || [];
+      if (!pages.length) throw new Error('No puzzle was generated.');
+      let at = cur < 0 ? pageModels.length : cur + 1;
+      pages.forEach((pg) => { pageModels.splice(at, 0, modelFromPage(pg)); at += 1; });
+      cur = at - 1; buildPageList(); renderPage();
+      closePuzzleInsert();
+      const label = PUZ_LABELS[type] || type;
+      setStatus(`Inserted ${pages.length} ${label} page${pages.length > 1 ? 's' : ''}.`, 'ok');
+    } catch (err) { el.puzStatus.textContent = err.message; }
+    finally { el.puzInsert.disabled = false; }
+  }
+  function savePageAsTemplate() {
+    const pm = pageModels[cur];
+    if (!pm || !pm.elements || !pm.elements.length) { setStatus('Add text or shapes to this page first, then save it as a template.', 'err'); return; }
+    const name = (window.prompt('Name this template:', pm.title && pm.title !== 'Blank' ? pm.title : 'My template') || '').trim();
+    if (!name) return;
+    const tpl = { id: 't' + Date.now().toString(36), name, refW: R(dims.usableWidth), refH: R(dims.usableHeight),
+      elements: pm.elements.map((e) => { const { _node, id, ...r } = e; return r; }) };
+    const list = loadSavedTemplates(); list.push(tpl); saveSavedTemplates(list);
+    setStatus(`Saved template “${name}”. Find it under Insert → Page template.`, 'ok');
+  }
+  function loadSavedTemplates() { try { return JSON.parse(localStorage.getItem('pf_templates') || '[]'); } catch (_) { return []; } }
+  function saveSavedTemplates(l) { try { localStorage.setItem('pf_templates', JSON.stringify(l)); } catch (_) { setStatus('Could not save the template (browser storage full?).', 'err'); } }
+  function deleteSavedTemplate(id) { saveSavedTemplates(loadSavedTemplates().filter((t) => t.id !== id)); }
+
+  // --- zoom / rulers ---
+  function fitScale() { const aw = (el.stageScroll.clientWidth || 700) - 24, ah = window.innerHeight - 200; return Math.max(0.15, Math.min(aw / dims.usableWidth, ah / dims.usableHeight, 1.5)); }
+  function applyZoom() {
+    el.stageInner.style.width = dims.usableWidth + 'px'; el.stageInner.style.height = dims.usableHeight + 'px'; el.stageInner.style.transform = `scale(${zoom})`;
+    el.stageOuter.style.width = Math.round(dims.usableWidth * zoom) + 'px'; el.stageOuter.style.height = Math.round(dims.usableHeight * zoom) + 'px';
+    el.zoomLabel.textContent = Math.round(zoom * 100) + '%';
+    const inch = PX_PER_IN * zoom;
+    el.rulerTop.style.background = `repeating-linear-gradient(90deg,#b6bccb 0 1px,transparent 1px ${inch / 4}px),repeating-linear-gradient(90deg,#7a8194 0 1px,transparent 1px ${inch}px)`;
+    el.rulerLeft.style.background = `repeating-linear-gradient(0deg,#b6bccb 0 1px,transparent 1px ${inch / 4}px),repeating-linear-gradient(0deg,#7a8194 0 1px,transparent 1px ${inch}px)`;
+    syncRulers();
+    if (spreadMode && !masterMode) layoutSpread(); else clearSpread();
+  }
+
+  // --- Two-page spread (View) ---
+  // Shows the active page next to its facing page (live, non-interactive) so you
+  // can check the gutter and across-the-spread layout. Recto (odd page numbers)
+  // sits on the right, like a real book opening.
+  const SPREAD_GUT = 28;
+  let spreadMode = false;
+  const activeIsLeft = (i) => i % 2 === 1;                 // even display number (i+1) = verso/left
+  function facingIndex(i) {
+    const j = i % 2 === 1 ? i + 1 : i - 1;
+    return (j >= 0 && j < pageModels.length) ? j : null;
+  }
+  function clearSpread() {
+    el.stageOuter.querySelectorAll('.spread-facing, .spread-gutter').forEach((n) => n.remove());
+    el.stageInner.style.position = ''; el.stageInner.style.left = ''; el.stageInner.style.top = '';
+  }
+  function layoutSpread() {
+    el.stageOuter.querySelectorAll('.spread-facing, .spread-gutter').forEach((n) => n.remove());
+    const pageW = dims.usableWidth, pageH = dims.usableHeight;
+    const rightX = (pageW + SPREAD_GUT) * zoom;
+    const aLeft = activeIsLeft(cur), fIdx = facingIndex(cur);
+    el.stageOuter.style.width = Math.round((2 * pageW + SPREAD_GUT) * zoom) + 'px';
+    el.stageOuter.style.height = Math.round(pageH * zoom) + 'px';
+    el.stageInner.style.position = 'absolute'; el.stageInner.style.top = '0';
+    el.stageInner.style.left = (aLeft ? 0 : rightX) + 'px';
+    if (fIdx != null && pageModels[fIdx]) {
+      const wrap = paintPageCanvas(pageModels[fIdx], fIdx, zoom, true);
+      wrap.classList.add('spread-facing');
+      wrap.style.position = 'absolute'; wrap.style.top = '0'; wrap.style.left = (aLeft ? rightX : 0) + 'px';
+      wrap.title = 'Click to edit this facing page';
+      wrap.addEventListener('click', () => selectPage(fIdx));
+      el.stageOuter.appendChild(wrap);
+    }
+    const band = document.createElement('div'); band.className = 'spread-gutter';
+    band.style.cssText = `position:absolute;top:0;height:${Math.round(pageH * zoom)}px;left:${Math.round(pageW * zoom)}px;width:${Math.round(SPREAD_GUT * zoom)}px;`;
+    el.stageOuter.appendChild(band);
+  }
+  function fitSpread() {
+    const aw = (el.stageScroll.clientWidth || 700) - 24, ah = window.innerHeight - 200;
+    return Math.max(0.12, Math.min(aw / (2 * dims.usableWidth + SPREAD_GUT), ah / dims.usableHeight, 1.5));
+  }
+  function toggleSpread() {
+    spreadMode = el.spreadToggle.checked;
+    if (spreadMode) zoom = Math.min(zoom, fitSpread());
+    renderPage(); updateViewButtons();
+    setStatus(spreadMode ? 'Two-page spread — the facing page is a live preview; click it to edit it.' : 'Single-page view.', 'ok');
+  }
+  // Drive the View-tab Single/Spread buttons (they set the hidden checkbox).
+  function setSpreadMode(on) { el.spreadToggle.checked = on; toggleSpread(); }
+  // Reflect Normal/Master and Single/Spread active state on the View buttons.
+  function updateViewButtons() {
+    if (el.viewNormal) el.viewNormal.classList.toggle('on', !masterMode);
+    if (el.viewMaster) el.viewMaster.classList.toggle('on', masterMode);
+    if (el.viewSingle) el.viewSingle.classList.toggle('on', !spreadMode);
+    if (el.viewSpread) el.viewSpread.classList.toggle('on', spreadMode);
+  }
+  // Align the ruler tick gradients + draw inch numbers against the page's actual
+  // on-screen position (the page is centred in the scroll area, so we can't just
+  // use scrollLeft). Called on zoom, scroll, and page render.
+  function syncRulers() {
+    const stage = el.editorMain.querySelector('.editor-stage');
+    if (!stage || stage.classList.contains('no-rulers')) return;
+    const inner = el.stageInner.getBoundingClientRect();
+    const offX = inner.left - el.rulerTop.getBoundingClientRect().left;
+    const offY = inner.top - el.rulerLeft.getBoundingClientRect().top;
+    const inch = PX_PER_IN * zoom;
+    el.rulerTop.style.backgroundPositionX = offX + 'px';
+    el.rulerLeft.style.backgroundPositionY = offY + 'px';
+    const marks = (ruler) => { let m = ruler.querySelector('.ruler-marks'); if (!m) { m = document.createElement('div'); m.className = 'ruler-marks'; ruler.appendChild(m); } return m; };
+    const wIn = Math.round(dims.usableWidth / PX_PER_IN), hIn = Math.round(dims.usableHeight / PX_PER_IN);
+    const mt = marks(el.rulerTop); mt.innerHTML = '';
+    for (let i = 0; i <= wIn; i++) { const s = document.createElement('span'); s.textContent = i; s.style.left = (offX + i * inch) + 'px'; mt.appendChild(s); }
+    const ml = marks(el.rulerLeft); ml.innerHTML = '';
+    for (let i = 0; i <= hIn; i++) { const s = document.createElement('span'); s.textContent = i; s.style.top = (offY + i * inch) + 'px'; ml.appendChild(s); }
+  }
+  const setZoom = (z) => { zoom = Math.max(0.15, Math.min(4, z)); applyZoom(); drawSel(); };
+  // Fit the page to the window width only (height may scroll) — Publisher's "Page Width".
+  function fitWidth() { const aw = (el.stageScroll.clientWidth || 700) - 24; return Math.max(0.15, Math.min(aw / dims.usableWidth, 4)); }
+  // View toggles: rulers, the page-rail sidebar, and the page boundary outline.
+  function toggleRulers() { el.editorMain.querySelector('.editor-stage').classList.toggle('no-rulers', !el.rulerToggle.checked); if (el.rulerToggle.checked) applyZoom(); }
+  function toggleNav() { el.editorMain.classList.toggle('no-nav', !el.navToggle.checked); applyZoom(); }
+  function toggleBounds() { el.stageInner.classList.toggle('show-bounds', el.boundToggle.checked); }
+
+  // Matter pages (title, copyright, …) position content via the page context,
+  // so their pieces are placed ABSOLUTELY at a measured page rect rather than in
+  // document flow. Content (puzzle) pages keep the flow + delta model.
+  const isMatterPage = (pm) => !!(pm && pm.role && pm.role !== 'content' && !pm.blank);
+  function applyAbsBase(c) {
+    if (!c._node) return;
+    c._node.style.position = 'absolute'; c._node.style.left = c.baseX + 'px'; c._node.style.top = c.baseY + 'px';
+    if (c.baseW) c._node.style.width = c.baseW + 'px';
+  }
+  // One-time faithful measure of a matter page: render its original body (no
+  // per-piece wrappers) and capture each top-level element's page rectangle.
+  function measureMatterBases(pm) {
+    const meas = document.createElement('div'); meas.className = 'pf-flow';
+    meas.style.cssText = 'position:absolute;top:0;left:0;visibility:hidden;min-height:' + dims.usableHeight + 'px;width:' + dims.usableWidth + 'px;';
+    meas.innerHTML = pm.comps.map((c) => c.html).join('');
+    el.stageInner.appendChild(meas);
+    const ir = el.stageInner.getBoundingClientRect();
+    const kids = [...meas.children];
+    pm.comps.forEach((c, i) => {
+      const k = kids[i]; if (!k) return;
+      const r = k.getBoundingClientRect();
+      c.baseX = (r.left - ir.left) / zoom; c.baseY = (r.top - ir.top) / zoom; c.baseW = r.width / zoom; c.baseH = r.height / zoom;
+    });
+    el.stageInner.removeChild(meas);
+    pm._measured = true;
+  }
+
+  // --- render ---
+  function renderPage() {
+    const pm = curModel(); highlightPage();
+    const matter = isMatterPage(pm);
+    el.stageInner.innerHTML = '';
+    el.stageInner.style.background = pageBgCss(pm && pm._bg);
+    const style = document.createElement('style'); style.textContent = scopeCss(pm.style, '#stageInner'); el.stageInner.appendChild(style);
+    renderBorderFrame(pm);
+    gridEl = document.createElement('div'); gridEl.className = 'pf-grid-overlay'; gridEl.style.display = el.gridToggle.checked ? '' : 'none'; el.stageInner.appendChild(gridEl);
+
+    el.border.value = pm._border || ''; syncBgUI(); applyZoom();
+    // Matter pages need their true page positions before creating pieces.
+    if (matter && pm.comps.length && !pm._measured) measureMatterBases(pm);
+
+    // Pieces: absolute (matter) or in original flow (content), in order.
+    flowEl = document.createElement('div'); flowEl.className = 'pf-flow';
+    if (matter) flowEl.style.minHeight = dims.usableHeight + 'px';
+    pm.comps.forEach((c) => {
+      const node = document.createElement('div'); node.className = 'pf-piece' + (matter ? ' pf-abs' : ''); node.dataset.key = c.key;
+      node.innerHTML = c.html; node.style.display = c.hidden ? 'none' : '';
+      c._node = node; node._ref = c; node.addEventListener('pointerdown', (ev) => onPointerDown(ev, c));
+      if (matter) applyAbsBase(c);
+      flowEl.appendChild(node);
+    });
+
+    // Free objects render in z-order, split across the puzzle: objects flagged
+    // `behind` sit UNDER the puzzle/title/word-list (backgrounds, watermarks,
+    // frames); the rest sit on top. The puzzle itself stays a protected object.
+    const ordered = pm.elements.slice().sort((a, b) => num(a.z, 0) - num(b.z, 0));
+    ordered.filter((e) => e.behind).forEach((e) => el.stageInner.appendChild(makeEl(e)));
+    el.stageInner.appendChild(flowEl);
+    ordered.filter((e) => !e.behind).forEach((e) => el.stageInner.appendChild(makeEl(e)));
+
+    vGuide = document.createElement('div'); vGuide.className = 'pf-guide pf-guide-v'; vGuide.style.display = 'none';
+    hGuide = document.createElement('div'); hGuide.className = 'pf-guide pf-guide-h'; hGuide.style.display = 'none';
+    selLayer = document.createElement('div'); selLayer.className = 'pf-sel-layer';
+    el.stageInner.appendChild(vGuide); el.stageInner.appendChild(hGuide); el.stageInner.appendChild(selLayer);
+    applyMarginGuide();
+    renderUserGuides();
+    if (!masterMode) renderMasterOverlay();
+
+    // Content: measure flow bases (no transform yet). Matter: bases already set.
+    requestAnimationFrame(() => {
+      if (!matter) measureBases(pm);
+      // A piece pinned during break-apart keeps its original page position even
+      // after its siblings are hidden (which would otherwise let it reflow up).
+      // Convert the pin to a one-time dx/dy delta against the fresh flow base.
+      pm.comps.forEach((c) => {
+        if (!c._pin) return;
+        c.dx = num(c._pinX, c.baseX) - c.baseX; c.dy = num(c._pinY, c.baseY) - c.baseY;
+        delete c._pin; delete c._pinX; delete c._pinY;
+      });
+      pm.comps.forEach(applyPieceTf);
+      // Auto-break imported puzzle pages once, after the pieces are measured
+      // (break-apart needs their on-screen geometry). breakApartPuzzle re-renders.
+      if (autoBreak && !matter && !masterMode && pm === pageModels[cur] && !pm._broken && pm.comps.some((c) => !c.hidden && BREAKABLE.includes(c.kind))) {
+        pm._broken = true; breakApartPuzzle(true); return;
+      }
+      sels = []; syncSelUI(); drawSel();
+    });
+  }
+  function measureBases(pm) {
+    const ir = el.stageInner.getBoundingClientRect();
+    pm.comps.forEach((c) => {
+      if (c.hidden) return;
+      const r = c._node.getBoundingClientRect();
+      c.baseX = (r.left - ir.left) / zoom; c.baseY = (r.top - ir.top) / zoom; c.baseW = r.width / zoom; c.baseH = r.height / zoom;
+    });
+  }
+  function applyPieceTf(c) { if (c._node) c._node.style.transform = (c.dx || c.dy || c.scale !== 1 || c.rot) ? `translate(${c.dx}px,${c.dy}px) rotate(${c.rot}deg) scale(${c.scale})` : ''; }
+
+  function makeEl(e) {
+    const node = document.createElement('div'); node.className = 'pf-node' + (e.behind ? ' pf-behind' : ''); node.innerHTML = elHtml(e);
+    e._node = node; node._ref = e; applyElTf(e);
+    node.addEventListener('pointerdown', (ev) => onPointerDown(ev, e));
+    if (e.kind === 'text') node.addEventListener('dblclick', () => editText(e));
+    if (e.kind === 'table') { node.addEventListener('dblclick', (ev) => editTableCell(e, ev)); node.addEventListener('pointerdown', (ev) => onTableCellDown(e, ev), true); }
+    if (e.kind === 'image') node.addEventListener('dblclick', () => pickImageFor(e));
+    return node;
+  }
+  function applyElTf(e) { if (e._node) e._node.style.transform = `translate(${num(e.x, 0)}px,${num(e.y, 0)}px) rotate(${num(e.rot, 0)}deg) scale(${num(e.scale, 1)})`; }
+  // Elements render through the engine's shared renderer (element-html.js), so
+  // what's on screen is byte-identical to what the PDF composer prints.
+  const elHtml = (e) => window.PFElements.elementHtml(e);
+  function allRefs() { const pm = curModel(); return [...pm.comps.filter((c) => !c.hidden), ...pm.elements]; }
+
+  // --- unified box model (page coords) ---
+  function box(ref) {
+    if (ref.group === 'piece') return { x: ref.baseX + ref.dx, y: ref.baseY + ref.dy, w: ref.baseW * ref.scale, h: ref.baseH * ref.scale };
+    const n = ref._node, s = num(ref.scale, 1); return { x: num(ref.x, 0), y: num(ref.y, 0), w: n.offsetWidth * s, h: n.offsetHeight * s };
+  }
+  function moveTo(ref, x, y) {
+    if (ref.group === 'piece') { ref.dx = x - ref.baseX; ref.dy = y - ref.baseY; applyPieceTf(ref); }
+    else { ref.x = x; ref.y = y; applyElTf(ref); }
+  }
+  function setScale(ref, s) { ref.scale = s; ref.group === 'piece' ? applyPieceTf(ref) : applyElTf(ref); }
+  function setRot(ref, r) { ref.rot = r; ref.group === 'piece' ? applyPieceTf(ref) : applyElTf(ref); }
+
+  // --- history ---
+  function snapshot(pm) { return JSON.stringify({ comps: pm.comps.map((c) => ({ key: c.key, dx: c.dx, dy: c.dy, scale: c.scale, rot: c.rot, hidden: c.hidden, locked: c.locked })), elements: pm.elements.map((e) => { const { _node, ...r } = e; return r; }), guides: pm.guides ? { v: pm.guides.v.slice(), h: pm.guides.h.slice() } : { v: [], h: [] } }); }
+  function pushUndo() { const pm = curModel(); pm.undo.push(snapshot(pm)); if (pm.undo.length > 60) pm.undo.shift(); pm.redo = []; }
+  function applySnap(pm, snap) { const s = JSON.parse(snap); const byKey = {}; pm.comps.forEach((c) => (byKey[c.key] = c)); s.comps.forEach((sc) => { const c = byKey[sc.key]; if (c) Object.assign(c, sc); }); pm.elements = s.elements.map((e) => ({ ...e, group: 'el' })); pm.guides = s.guides ? { v: (s.guides.v || []).slice(), h: (s.guides.h || []).slice() } : { v: [], h: [] }; }
+  function undo() { const pm = curModel(); if (!pm.undo.length) return; pm.redo.push(snapshot(pm)); applySnap(pm, pm.undo.pop()); if (masterMode) master.elements = pm.elements; renderPage(); }
+  function redo() { const pm = curModel(); if (!pm.redo.length) return; pm.undo.push(snapshot(pm)); applySnap(pm, pm.redo.pop()); if (masterMode) master.elements = pm.elements; renderPage(); }
+
+  // --- selection ---
+  const isSel = (r) => sels.indexOf(r) >= 0;
+  function setSel(a) { if (cropTarget && a[0] !== cropTarget) endCrop(true); sels = a.slice(); syncSelUI(); drawSel(); }
+  const primary = () => sels[sels.length - 1];
+  // Which resize handles an object gets: shapes resize freely on all 8;
+  // text/images resize width on the sides and scale on the corners; puzzle
+  // pieces scale on the corners only.
+  function handleDirs(ref) {
+    if (ref.kind === 'shape') return ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+    // A linked (flow) text box also gets a bottom handle to size its region.
+    if (ref.kind === 'text' && ref.chainId) return ['nw', 'ne', 'se', 'sw', 'e', 'w', 's'];
+    if (ref.kind === 'text' || ref.kind === 'image') return ['nw', 'ne', 'se', 'sw', 'e', 'w'];
+    return ['nw', 'ne', 'se', 'sw'];
+  }
+  function drawSel() {
+    if (!selLayer) return; selLayer.innerHTML = '';
+    if (cropTarget) return; // crop overlay replaces the selection handles
+    sels.forEach((ref) => {
+      if (!ref._node) return; const b = box(ref);
+      const d = document.createElement('div'); d.className = 'pf-selbox'; d.style.transform = `translate(${b.x}px,${b.y}px) rotate(${num(ref.rot, 0)}deg)`; d.style.width = b.w + 'px'; d.style.height = b.h + 'px';
+      if (sels.length === 1 && !ref.locked) {
+        handleDirs(ref).forEach((dir) => {
+          const h = document.createElement('div'); h.className = 'pf-h'; h.dataset.d = dir;
+          h.addEventListener('pointerdown', (ev) => { ev.stopPropagation(); startResize(ev, ref, dir); });
+          d.appendChild(h);
+        });
+        const stem = document.createElement('div'); stem.className = 'pf-rot-stem'; d.appendChild(stem);
+        const rot = document.createElement('div'); rot.className = 'pf-rot'; rot.title = 'Rotate (Shift snaps to 15°)';
+        rot.addEventListener('pointerdown', (ev) => { ev.stopPropagation(); startRotate(ev, ref); });
+        d.appendChild(rot);
+      }
+      selLayer.appendChild(d);
+    });
+  }
+  function syncFontUI(one) {
+    const isText = one && one.kind === 'text';
+    const setOn = (sel, on) => document.querySelectorAll(sel).forEach((b) => b.classList.toggle('on', !!on));
+    setOn('.js-bold', isText && one.bold);
+    setOn('.js-italic', isText && one.italic);
+    setOn('.js-underline', isText && one.underline);
+    document.querySelectorAll('.palign').forEach((b) => b.classList.toggle('on', isText && (one.align || 'left') === b.dataset.align));
+    if (isText) {
+      const setVal = (sel, v) => document.querySelectorAll(sel).forEach((i) => { i.value = v; });
+      setVal('.js-font-size', num(one.fontSize, 24));
+      setVal('.js-font-color', one.color || '#222222');
+      setVal('.js-font-family', one.fontFamily || 'sans');
+      setVal('.js-line-spacing', String(num(one.lineHeight, 1.25)));
+      if (el.tbHyphenBtn) el.tbHyphenBtn.classList.toggle('on', !!one.hyphens);
+      // Typography → Stylistic Sets menu: mark the active set and toggles.
+      const styMenu = el.tbStyDrop && el.tbStyDrop.querySelector('.rdrop-menu');
+      if (styMenu) {
+        const ss = Math.round(num(one.stySet, 0));
+        styMenu.querySelectorAll('[data-act]').forEach((b) => {
+          const a = b.dataset.act;
+          const on = a === 'ss' + ss || (a === 'swash' && one.swash) || (a === 'salt' && one.styAlt) || (a === 'calt' && one.contextual !== false);
+          b.classList.toggle('rdrop-on', !!on);
+        });
+      }
+    }
+  }
+  function syncShapeFormatUI() {
+    const ok = sfApplicable(); const o = sfSel();
+    if (el.sfNone) el.sfNone.classList.toggle('hidden', ok);
+    if (el.sfControls) el.sfControls.classList.toggle('hidden', !ok);
+    if (!ok || !o) return;
+    if (el.sfW) el.sfW.value = Math.round(num(o.w, 0));
+    if (el.sfH) el.sfH.value = Math.round(num(o.h, o._node && o._node.firstElementChild ? o._node.firstElementChild.offsetHeight : 0));
+    if (el.sfEditText) el.sfEditText.style.display = o.kind === 'text' ? '' : 'none';
+  }
+  function syncSelUI() {
+    const has = sels.length > 0; el.selNone.classList.toggle('hidden', has); el.selControls.classList.toggle('hidden', !has);
+    const one = sels.length === 1 ? sels[0] : null; const isText = one && one.kind === 'text'; const isImg = one && one.kind === 'image'; const isShape = one && one.kind === 'shape'; const isTable = one && one.kind === 'table'; const isQr = one && one.kind === 'qr'; const isEl = one && one.group === 'el';
+    syncFontUI(one);
+    updateContextTab();
+    syncShapeFormatUI();
+    syncTableTabsUI();
+    syncPictureUI();
+    syncQrUI(one);
+    if (!has) return;
+    document.querySelectorAll('.tb-group').forEach((g) => { g.style.display = isText ? '' : 'none'; });
+    // Generic Size / Arrange / Object groups live on the Shape Format tab for a
+    // text box, so hide them on the (pure) Text Box tab; keep them for images/tables/QR.
+    document.querySelectorAll('#selControls .gen-group').forEach((g) => { g.style.display = isText ? 'none' : ''; });
+    el.measurePanel.style.display = one && !isText ? '' : 'none';
+    el.shapeProps.style.display = isShape ? '' : 'none';
+    if (el.tableProps) el.tableProps.style.display = isTable ? '' : 'none';
+    el.mWField.style.display = isEl && !isTable ? '' : 'none'; el.mHField.style.display = isShape ? '' : 'none';
+    el.dupObj.style.display = isEl ? '' : 'none'; el.deleteObj.style.display = isEl ? '' : 'none';
+    el.hideObj.style.display = one && !isEl ? '' : 'none';
+    el.lockObj.textContent = one && one.locked ? 'Unlock' : 'Lock';
+    el.groupBtn.style.display = sels.length >= 2 ? '' : 'none';
+    el.ungroupBtn.style.display = sels.some((r) => r.gid) ? '' : 'none';
+    if (one) {
+      const b = box(one); el.mX.value = Math.round(b.x); el.mY.value = Math.round(b.y); el.mScale.value = Math.round(num(one.scale, 1) * 100); el.mRot.value = Math.round(num(one.rot, 0));
+      if (isEl && !isTable) el.mW.value = Math.round(num(one.kind === 'image' ? one.width : one.w, 0));
+      if (isShape) el.mH.value = Math.round(num(one.h, 0));
+      if (isShape) {
+        el.fillColor.value = /^#/.test(one.fill || '') ? one.fill : '#ffd43b';
+        el.strokeColor.value = /^#/.test(one.stroke || '') ? one.stroke : '#222222';
+        el.strokeW.value = num(one.strokeW, 2); el.noFill.checked = one.fill === 'none';
+      }
+      if (isTable && el.tblBorder) {
+        el.tblBorder.value = /^#/.test(one.borderColor || '') ? one.borderColor : '#333333';
+        el.tblHeaderFill.value = /^#/.test(one.headerFill || '') ? one.headerFill : '#eef1fe';
+        el.tblHeader.checked = !!one.header;
+      }
+    }
+  }
+
+  function snapTargets(excl) {
+    // Page edges/centers always snap; objects and guides are gated by the
+    // Page Design → Align To checkboxes.
+    const xs = [0, dims.usableWidth / 2, dims.usableWidth], ys = [0, dims.usableHeight / 2, dims.usableHeight];
+    if (alignObjects) for (const r of allRefs()) { if (excl.indexOf(r) >= 0 || !r._node) continue; const b = box(r); xs.push(b.x, b.x + b.w / 2, b.x + b.w); ys.push(b.y, b.y + b.h / 2, b.y + b.h); }
+    if (alignGuides) { const g = ensureGuides(curModel()); if (g) { xs.push(...g.v); ys.push(...g.h); } }
+    return { xs, ys };
+  }
+  const showGuide = (g, a, v) => { g.style.display = ''; if (a === 'x') g.style.left = v + 'px'; else g.style.top = v + 'px'; };
+  const hideGuides = () => { if (vGuide) vGuide.style.display = 'none'; if (hGuide) hGuide.style.display = 'none'; };
+
+  // --- user ruler guides (drag off a ruler to place; snap objects to them) ----
+  // Stored per page in unscaled page px: pm.guides = { v: [x…], h: [y…] }.
+  function ensureGuides(pm) { if (pm && !pm.guides) pm.guides = { v: [], h: [] }; return pm && pm.guides; }
+  function renderUserGuides() {
+    el.stageInner.querySelectorAll('.pf-user-guide').forEach((n) => n.remove());
+    const pm = curModel(); const g = ensureGuides(pm); if (!g) return;
+    g.v.forEach((x, i) => el.stageInner.appendChild(makeGuideEl('v', x, i)));
+    g.h.forEach((y, i) => el.stageInner.appendChild(makeGuideEl('h', y, i)));
+  }
+  function makeGuideEl(axis, pos, idx) {
+    const node = document.createElement('div');
+    node.className = 'pf-user-guide ' + axis;
+    node.style[axis === 'v' ? 'left' : 'top'] = pos + 'px';
+    node.title = 'Drag to move · double-click (or drag onto the ruler) to remove';
+    node.addEventListener('pointerdown', (ev) => startGuideDrag(ev, axis, idx));
+    node.addEventListener('dblclick', (ev) => { ev.stopPropagation(); const g = ensureGuides(curModel()); pushUndo(); (axis === 'v' ? g.v : g.h).splice(idx, 1); renderUserGuides(); });
+    return node;
+  }
+  // Position of a client point in unscaled page px along one axis.
+  const pageX = (clientX) => (clientX - el.stageInner.getBoundingClientRect().left) / zoom;
+  const pageY = (clientY) => (clientY - el.stageInner.getBoundingClientRect().top) / zoom;
+
+  // Press on a ruler and drag onto the page to drop a new guide.
+  function startRulerCreate(ev, axis) {
+    ev.preventDefault();
+    const pm = curModel(); const g = ensureGuides(pm); if (!g) return;
+    const preview = document.createElement('div');
+    preview.className = 'pf-user-guide ' + axis + ' dragging';
+    el.stageInner.appendChild(preview);
+    let pos = null;
+    const move = (e) => {
+      const rect = el.stageInner.getBoundingClientRect();
+      if (axis === 'h') { pos = Math.max(0, Math.min(dims.usableHeight, (e.clientY - rect.top) / zoom)); preview.style.top = pos + 'px'; }
+      else { pos = Math.max(0, Math.min(dims.usableWidth, (e.clientX - rect.left) / zoom)); preview.style.left = pos + 'px'; }
+    };
+    const up = (e) => {
+      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up);
+      preview.remove();
+      const rect = el.stageInner.getBoundingClientRect();
+      const onPage = axis === 'h' ? e.clientY >= rect.top : e.clientX >= rect.left; // dropped onto the page, not back on the ruler
+      if (pos == null || !onPage) return;
+      pushUndo();
+      (axis === 'h' ? g.h : g.v).push(Math.round(pos));
+      renderUserGuides();
+    };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+    move(ev);
+  }
+
+  // Drag an existing guide; releasing back over the ruler removes it.
+  function startGuideDrag(ev, axis, idx) {
+    ev.preventDefault(); ev.stopPropagation();
+    const g = ensureGuides(curModel()); const arr = axis === 'v' ? g.v : g.h; pushUndo();
+    const move = (e) => {
+      arr[idx] = axis === 'v'
+        ? Math.round(Math.max(0, Math.min(dims.usableWidth, pageX(e.clientX))))
+        : Math.round(Math.max(0, Math.min(dims.usableHeight, pageY(e.clientY))));
+      renderUserGuides();
+    };
+    const up = (e) => {
+      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up);
+      const rect = el.stageInner.getBoundingClientRect();
+      if ((axis === 'v' && e.clientX < rect.left) || (axis === 'h' && e.clientY < rect.top)) { arr.splice(idx, 1); renderUserGuides(); }
+    };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+
+  // --- drag / resize ---
+  // Grouped objects select and move as one (Publisher-style groups).
+  function expandGroups(list) {
+    const gids = new Set(list.map((r) => r.gid).filter(Boolean));
+    if (!gids.size) return list;
+    const out = list.slice();
+    allRefs().forEach((r) => { if (r.gid && gids.has(r.gid) && out.indexOf(r) < 0 && !r.locked) out.push(r); });
+    return out;
+  }
+  function onPointerDown(ev, ref) {
+    // A cell (or text box) mid-edit: let the browser place the caret, don't drag.
+    if (ev.target && ev.target.isContentEditable) return;
+    // Picking a link target (Text Box → Linking → Create Link).
+    if (linkPickMode) { ev.preventDefault(); ev.stopPropagation(); finishLink(ref); return; }
+    // Picking a swap partner (Picture Format → Swap).
+    if (swapPickMode) { ev.preventDefault(); ev.stopPropagation(); const src = swapPickMode; cancelSwap(); if (ref.kind === 'image') swapContents(src, ref); else setStatus('Swap needs another picture.', ''); return; }
+    ev.preventDefault(); hideCtx();
+    if (painter && ev.button !== 2 && applyPainter(ref)) { setSel([ref]); return; }
+    if (ev.button === 2) { if (!isSel(ref)) setSel(expandGroups([ref])); return; }
+    if (ref.locked) { setSel([ref]); return; }
+    // Shift / Ctrl / Cmd extend the selection (Ctrl/Cmd is what most people
+    // reach for). A modifier-click on an already-selected object toggles it out.
+    const additive = ev.shiftKey || ev.ctrlKey || ev.metaKey;
+    if (additive) {
+      if (isSel(ref)) {
+        const gid = ref.gid;
+        sels = sels.filter((r) => r !== ref && !(gid && r.gid === gid));
+        syncSelUI(); drawSel(); return; // toggled out — nothing to drag
+      }
+      sels.push(ref);
+    } else if (!isSel(ref)) sels = [ref];
+    sels = expandGroups(sels);
+    syncSelUI(); drawSel();
+    const group = sels.slice(); const starts = group.map((r) => { const b = box(r); return { r, x: b.x, y: b.y, w: b.w, h: b.h }; });
+    const sx = ev.clientX, sy = ev.clientY; let pushed = false;
+    const move = (e) => {
+      let dx = (e.clientX - sx) / zoom, dy = (e.clientY - sy) / zoom;
+      if (!pushed && (Math.abs(dx) > 1 || Math.abs(dy) > 1)) { pushUndo(); pushed = true; }
+      const p = starts.find((s) => s.r === primary()) || starts[0];
+      let nx = p.x + dx, ny = p.y + dy;
+      if (el.gridToggle.checked) { nx = Math.round(nx / GRID) * GRID; ny = Math.round(ny / GRID) * GRID; dx = nx - p.x; dy = ny - p.y; }
+      if (el.snapToggle.checked) {
+        const t = snapTargets(group), d = 7 / zoom;
+        let bx = null; for (const off of [0, p.w / 2, p.w]) for (const tx of t.xs) { const dd = tx - (nx + off); if (Math.abs(dd) < d && (!bx || Math.abs(dd) < Math.abs(bx.d))) bx = { d: dd, v: tx }; }
+        if (bx) { dx += bx.d; showGuide(vGuide, 'x', bx.v); } else vGuide.style.display = 'none';
+        let by = null; for (const off of [0, p.h / 2, p.h]) for (const ty of t.ys) { const dd = ty - (ny + off); if (Math.abs(dd) < d && (!by || Math.abs(dd) < Math.abs(by.d))) by = { d: dd, v: ty }; }
+        if (by) { dy += by.d; showGuide(hGuide, 'y', by.v); } else hGuide.style.display = 'none';
+      }
+      starts.forEach((s) => moveTo(s.r, s.x + dx, s.y + dy)); drawSel();
+    };
+    const up = () => { hideGuides(); if (sels.length === 1) syncSelUI(); window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+  function startResize(ev, ref, dir) {
+    ev.preventDefault(); pushUndo();
+    const b0 = box(ref); const r = el.stageInner.getBoundingClientRect();
+    const right = b0.x + b0.w, bottom = b0.y + b0.h;
+    const move = (e) => {
+      const px = (e.clientX - r.left) / zoom, py = (e.clientY - r.top) / zoom;
+      if (ref.kind === 'shape') {
+        // Shapes resize their intrinsic w/h; the opposite edge stays put.
+        let w = ref.w, h = ref.h;
+        if (dir.includes('e')) w = px - b0.x;
+        if (dir.includes('w')) w = right - px;
+        if (dir.includes('s')) h = py - b0.y;
+        if (dir.includes('n')) h = bottom - py;
+        ref.w = Math.max(8, Math.round(w)); ref.h = Math.max(4, Math.round(h));
+        ref._node.innerHTML = elHtml(ref);
+        const nb = box(ref);
+        moveTo(ref, dir.includes('w') ? right - nb.w : b0.x, dir.includes('n') ? bottom - nb.h : b0.y);
+      } else if (dir === 's' && ref.kind === 'text' && ref.chainId) {
+        // Bottom handle on a linked box sets the flow region height; text reflows.
+        ref.flowH = Math.max(24, Math.round((py - b0.y) / num(ref.scale, 1)));
+        reflowChain(ref.chainId);
+      } else if ((dir === 'e' || dir === 'w') && (ref.kind === 'text' || ref.kind === 'image')) {
+        // Side handles set the text box / image width.
+        const w = Math.max(20, Math.round((dir === 'e' ? px - b0.x : right - px) / num(ref.scale, 1)));
+        if (ref.kind === 'text') ref.w = w; else ref.width = w;
+        ref._node.innerHTML = elHtml(ref);
+        const nb = box(ref);
+        moveTo(ref, dir === 'w' ? right - nb.w : b0.x, b0.y);
+      } else {
+        // Corner handles scale proportionally; the opposite corner stays put.
+        const natW = ref.group === 'piece' ? ref.baseW : ref._node.offsetWidth;
+        const natH = ref.group === 'piece' ? ref.baseH : ref._node.offsetHeight;
+        const ax = dir.includes('w') ? right : b0.x;
+        const ay = dir.includes('n') ? bottom : b0.y;
+        const s = Math.max(0.15, Math.min(8, Math.max(Math.abs(px - ax) / (natW || 1), Math.abs(py - ay) / (natH || 1))));
+        setScale(ref, s);
+        const nb = box(ref);
+        moveTo(ref, dir.includes('w') ? ax - nb.w : b0.x, dir.includes('n') ? ay - nb.h : b0.y);
+      }
+      drawSel(); syncSelUI();
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+  function startRotate(ev, ref) {
+    ev.preventDefault(); pushUndo();
+    const r = el.stageInner.getBoundingClientRect();
+    const b = box(ref); const cx = b.x + b.w / 2, cy = b.y + b.h / 2;
+    const move = (e) => {
+      const px = (e.clientX - r.left) / zoom, py = (e.clientY - r.top) / zoom;
+      let ang = (Math.atan2(py - cy, px - cx) * 180) / Math.PI + 90;
+      if (e.shiftKey) ang = Math.round(ang / 15) * 15;
+      ang = ((ang + 180) % 360 + 360) % 360 - 180;
+      setRot(ref, Math.round(ang)); drawSel(); syncSelUI();
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+
+  // --- align / distribute ---
+  function alignSel(kind) {
+    if (!sels.length) return; pushUndo(); const horiz = ['left', 'centerh', 'right'].includes(kind); let lo, hi;
+    if (sels.length >= 2) { const bs = sels.map(box); lo = Math.min(...bs.map((b) => (horiz ? b.x : b.y))); hi = Math.max(...bs.map((b) => (horiz ? b.x + b.w : b.y + b.h))); }
+    else { lo = 0; hi = horiz ? dims.usableWidth : dims.usableHeight; }
+    const mid = (lo + hi) / 2;
+    sels.forEach((ref) => { const b = box(ref);
+      if (kind === 'left') moveTo(ref, lo, b.y); else if (kind === 'right') moveTo(ref, hi - b.w, b.y); else if (kind === 'centerh') moveTo(ref, Math.round(mid - b.w / 2), b.y);
+      else if (kind === 'top') moveTo(ref, b.x, lo); else if (kind === 'bottom') moveTo(ref, b.x, hi - b.h); else if (kind === 'middle') moveTo(ref, b.x, Math.round(mid - b.h / 2));
+    });
+    drawSel(); syncSelUI();
+  }
+  function distribute(axis) {
+    if (sels.length < 3) return; pushUndo();
+    const items = sels.map((r) => ({ r, b: box(r) })).sort((a, b) => (axis === 'x' ? (a.b.x + a.b.w / 2) - (b.b.x + b.b.w / 2) : (a.b.y + a.b.h / 2) - (b.b.y + b.b.h / 2)));
+    const c0 = axis === 'x' ? items[0].b.x + items[0].b.w / 2 : items[0].b.y + items[0].b.h / 2;
+    const last = items[items.length - 1].b; const c1 = axis === 'x' ? last.x + last.w / 2 : last.y + last.h / 2;
+    const step = (c1 - c0) / (items.length - 1);
+    items.forEach((it, i) => { const tc = c0 + step * i; if (axis === 'x') moveTo(it.r, Math.round(tc - it.b.w / 2), it.b.y); else moveTo(it.r, it.b.x, Math.round(tc - it.b.h / 2)); });
+    drawSel();
+  }
+
+  // --- arrange / object ops ---
+  function reorder(kind) {
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el') return; pushUndo();
+    const arr = curModel().elements; const zs = arr.map((e) => num(e.z, 100));
+    // "Send to back" drops the object behind the puzzle layer; "Bring to front"
+    // pulls it back above. Forward/backward step it within its current layer.
+    if (kind === 'front') { o.behind = false; o.z = Math.max(...zs) + 10; }
+    else if (kind === 'back') { o.behind = true; o.z = Math.min(...zs) - 10; }
+    else if (kind === 'forward') o.z = num(o.z, 100) + 15;
+    else if (kind === 'backward') o.z = num(o.z, 100) - 15;
+    renderPage(); setTimeout(() => setSel([o]), 0);
+  }
+  // --- Break apart a puzzle: title / instructions / word-list pieces become
+  // ordinary editable text objects, matching their on-screen typography. The
+  // GRID stays a protected piece (integrity, reroll, and answer keys intact).
+  const BREAKABLE = ['title', 'instructions', 'wordlist'];
+  function canBreakApart() {
+    const pm = pageModels[cur];
+    return !!(pm && !isMatterPage(pm) && !masterMode && pm.comps.some((c) => !c.hidden && BREAKABLE.includes(c.kind)));
+  }
+  const rgbToHex = (rgb) => {
+    const m = /rgba?\((\d+),\s*(\d+),\s*(\d+)/.exec(rgb || '');
+    if (!m) return '#222222';
+    const h = (n) => Number(n).toString(16).padStart(2, '0');
+    return '#' + h(m[1]) + h(m[2]) + h(m[3]);
+  };
+  const mapFontFamily = (ff) => {
+    const s = (ff || '').toLowerCase();
+    if (s.includes('courier') || s.includes('mono')) return 'mono';
+    if (s.includes('comic') || s.includes('cursive')) return 'hand';
+    if (s.includes('georgia') || s.includes('times') || (s.includes('serif') && !s.includes('sans'))) return 'serif';
+    return 'sans';
+  };
+  // The word list is a multi-column <ul>; rebuild it as an editable TABLE that
+  // preserves the columns (plain innerText would collapse it to one column).
+  function wordlistToTable(c, pm) {
+    const node = c._node; if (!node) return false;
+    const ul = node.querySelector('ul');
+    const lis = ul ? [...ul.querySelectorAll('li')] : [];
+    const words = lis.map((li) => li.textContent.trim()).filter(Boolean);
+    if (!ul || !words.length) return false;
+    const ir = el.stageInner.getBoundingClientRect();
+    const boxOf = (n) => { const r = n.getBoundingClientRect(); return { x: (r.left - ir.left) / zoom, y: (r.top - ir.top) / zoom, w: r.width / zoom, h: r.height / zoom }; };
+    // Keep the "WORDS TO FIND" heading as its own text object above the table.
+    const h2 = node.querySelector('h2');
+    if (h2 && h2.textContent.trim()) {
+      const hb = boxOf(h2); const hcs = getComputedStyle(h2);
+      pm.elements.push({ group: 'el', id: uid++, kind: 'text', x: Math.round(hb.x), y: Math.round(hb.y), scale: 1, rot: 0, z: 80,
+        w: Math.max(60, Math.round(hb.w)), text: h2.textContent.trim(),
+        fontSize: Math.max(8, Math.round(parseFloat(hcs.fontSize))), bold: parseInt(hcs.fontWeight, 10) >= 600, italic: false,
+        align: 'center', color: rgbToHex(hcs.color), lineHeight: 1.3, fontFamily: mapFontFamily(hcs.fontFamily) });
+    }
+    // Detect the column count from the rendered layout, then fill column-major
+    // to match CSS balanced columns (down column 1, then column 2, …).
+    const colXs = [];
+    [...new Set(lis.map((li) => Math.round(boxOf(li).x)))].sort((a, z) => a - z).forEach((x) => { if (!colXs.length || x - colXs[colXs.length - 1] > 20) colXs.push(x); });
+    const cols = Math.min(Math.max(1, colXs.length), 6, words.length);
+    const rows = Math.ceil(words.length / cols);
+    const cells = Array.from({ length: rows }, () => Array.from({ length: cols }, () => ''));
+    words.forEach((w, i) => { const col = Math.floor(i / rows), row = i % rows; if (row < rows && col < cols) cells[row][col] = w; });
+    const ub = boxOf(ul); const lcs = getComputedStyle(lis[0] || ul);
+    pm.elements.push({ group: 'el', id: uid++, kind: 'table', x: Math.round(ub.x), y: Math.round(ub.y), scale: 1, rot: 0, z: 80,
+      rows, cols, cells, colW: Array(cols).fill(Math.max(50, Math.round(ub.w / cols))), header: false,
+      borderColor: '#333333', borderW: 0, headerFill: '#eef1fe', cellPad: 4,
+      fontSize: Math.max(8, Math.round(parseFloat(lcs.fontSize))), fontFamily: mapFontFamily(lcs.fontFamily),
+      color: rgbToHex(lcs.color), align: 'center' });
+    c.hidden = true;
+    return true;
+  }
+  function breakApartPuzzle(silent) {
+    const pm = pageModels[cur];
+    if (!canBreakApart()) { if (!silent) setStatus('Open a puzzle page with a title or word list to break apart.', 'err'); return; }
+    const targets = pm.comps.filter((c) => !c.hidden && BREAKABLE.includes(c.kind));
+    pushUndo();
+    // Pin every piece that will REMAIN visible (the grid) to where it sits now.
+    // Once the title/instructions/word-list pieces are hidden they leave the
+    // flow, so an un-pinned grid would slide up and overlap the new text
+    // objects; the pin (applied on the next render) holds it in place.
+    pm.comps.forEach((c) => {
+      if (c.hidden || BREAKABLE.includes(c.kind)) return;
+      const b = box(c); c._pin = true; c._pinX = b.x; c._pinY = b.y;
+    });
+    let made = 0;
+    targets.forEach((c) => {
+      // Word list → editable multi-column table; everything else → text.
+      if (c.kind === 'wordlist' && wordlistToTable(c, pm)) { made += 1; return; }
+      const styled = (c._node && c._node.firstElementChild) || c._node;
+      const cs = styled ? getComputedStyle(styled) : null;
+      const text = (c._node ? c._node.innerText : c.html.replace(/<[^>]+>/g, ' ')).replace(/\n{3,}/g, '\n\n').trim();
+      if (!text) { c.hidden = true; return; }
+      const b = box(c);
+      pm.elements.push({
+        group: 'el', id: uid++, kind: 'text',
+        x: Math.round(b.x), y: Math.round(b.y), scale: 1, rot: 0, z: 80,
+        w: Math.max(60, Math.round(b.w)), text,
+        fontSize: cs ? Math.max(8, Math.round(parseFloat(cs.fontSize))) : (c.kind === 'title' ? 30 : 16),
+        bold: cs ? parseInt(cs.fontWeight, 10) >= 600 : c.kind === 'title',
+        italic: cs ? cs.fontStyle === 'italic' : false,
+        align: cs && ['left', 'center', 'right'].includes(cs.textAlign) ? cs.textAlign : (c.kind === 'title' ? 'center' : 'left'),
+        color: cs ? rgbToHex(cs.color) : '#222222',
+        lineHeight: cs ? Math.min(3, Math.max(0.8, parseFloat(cs.lineHeight) / parseFloat(cs.fontSize) || 1.3)) : 1.3,
+        fontFamily: cs ? mapFontFamily(cs.fontFamily) : 'sans',
+      });
+      c.hidden = true;                       // hide the baked piece (undo restores it)
+      made += 1;
+    });
+    renderPage();
+    if (!silent) setStatus(`Broke apart ${made} label${made === 1 ? '' : 's'} into editable text — the puzzle grid stays protected. Undo to reverse.`, 'ok');
+  }
+
+  function flip(axis) { const o = sels.length === 1 && sels[0]; if (!o || (o.kind !== 'image' && o.kind !== 'shape')) return; pushUndo(); if (axis === 'h') o.flipH = !o.flipH; else o.flipV = !o.flipV; o._node.innerHTML = elHtml(o); }
+  const norm360 = (d) => ((Math.round(d) % 360) + 360) % 360;
+  function rotateBy(delta) { if (!sels.length) return; pushUndo(); sels.forEach((r) => setRot(r, norm360(num(r.rot, 0) + delta))); drawSel(); syncSelUI(); }
+  function freeRotate() {
+    const o = sels.length === 1 && sels[0]; if (!o) { setStatus('Select one object to rotate.', ''); return; }
+    const v = window.prompt('Rotate to how many degrees?', String(norm360(num(o.rot, 0))));
+    if (v == null) return; const n = Number(v); if (!Number.isFinite(n)) return;
+    pushUndo(); setRot(o, norm360(n)); drawSel(); syncSelUI();
+  }
+  function toggleLock() { const o = sels.length === 1 && sels[0]; if (!o) return; pushUndo(); o.locked = !o.locked; syncSelUI(); }
+
+  function addElement(e) { pushUndo(); curModel().elements.push(e); el.stageInner.insertBefore(makeEl(e), selLayer); setSel([e]); return e; }
+  function addText() { const pm = curModel(); addElement({ group: 'el', id: uid++, kind: 'text', x: Math.round(dims.usableWidth / 2 - 100), y: Math.round(dims.usableHeight / 2), scale: 1, rot: 0, z: 100, text: 'Your text', fontSize: 28, color: '#222222', align: 'left', w: 240, fontFamily: (pm && pm._font) || 'sans' }); }
+  function addImageFile(file) { const r = new FileReader(); r.onload = () => { const o = addElement({ group: 'el', id: uid++, kind: 'image', x: Math.round(dims.usableWidth / 2 - 80), y: Math.round(dims.usableHeight / 2 - 80), scale: 1, rot: 0, z: 100, src: r.result, width: 160 }); captureNatSize(o); }; r.readAsDataURL(file); }
+  // An empty picture frame — double-click it (or use Insert → Picture) to fill.
+  function addPicturePlaceholder() {
+    addElement({ group: 'el', id: uid++, kind: 'image', placeholder: true, x: Math.round(dims.usableWidth / 2 - 100), y: Math.round(dims.usableHeight / 2 - 70), scale: 1, rot: 0, z: 100, width: 200, h: 140 });
+  }
+  // Fill (or replace) an image element by picking a file from disk.
+  function pickImageFor(e) {
+    const inp = document.createElement('input'); inp.type = 'file'; inp.accept = 'image/*';
+    inp.addEventListener('change', () => {
+      const f = inp.files && inp.files[0]; if (!f) return;
+      const r = new FileReader();
+      r.onload = () => { pushUndo(); e.src = r.result; e.placeholder = false; delete e.crop; captureNatSize(e); e._node.innerHTML = elHtml(e); requestAnimationFrame(drawSel); };
+      r.readAsDataURL(f);
+    });
+    inp.click();
+  }
+
+  // --- Picture Format tab (contextual: adjust / style / arrange a picture) ---
+  const selImage = () => { const o = sels.length === 1 && sels[0]; return o && o.kind === 'image' ? o : null; };
+  const picRerender = (o) => { o._node.innerHTML = elHtml(o); drawSel(); };
+  const RECOLOR_FILTERS = { grayscale: 'grayscale(1)', sepia: 'sepia(0.75)', washout: 'grayscale(.4) brightness(1.45) contrast(.7)', blue: 'grayscale(1) sepia(1) hue-rotate(170deg) saturate(4)', gold: 'sepia(1) saturate(2.2) hue-rotate(-12deg)', green: 'grayscale(1) sepia(1) hue-rotate(75deg) saturate(2.5)' };
+  const CORRECTIONS = [
+    { label: 'Brighten', b: 1.3, c: 1 }, { label: 'Normal', b: 1, c: 1 }, { label: 'Darken', b: 0.72, c: 1 },
+    { label: 'More Contrast', b: 1, c: 1.45 }, { label: 'Soften', b: 1.1, c: 0.78 }, { label: 'Sharpen', b: 1.05, c: 1.25 },
+  ];
+  const RECOLORS = [['', 'None'], ['grayscale', 'Grayscale'], ['sepia', 'Sepia'], ['washout', 'Washout'], ['blue', 'Blue'], ['gold', 'Gold'], ['green', 'Green']];
+  function picPreviewBtn(filter, label) {
+    const b = document.createElement('button'); b.type = 'button'; b.className = 'pic-sw rdrop-item'; b.title = label;
+    const sw = document.createElement('span'); sw.className = 'pic-sw-img'; sw.style.filter = filter || 'none';
+    b.appendChild(sw); return b;
+  }
+  function buildPicMenus() {
+    const corr = document.getElementById('picCorrMenu');
+    if (corr) { corr.innerHTML = ''; const g = document.createElement('div'); g.className = 'pic-grid';
+      CORRECTIONS.forEach((c) => { const b = picPreviewBtn(`brightness(${c.b}) contrast(${c.c})`, c.label); b.addEventListener('click', () => { const o = selImage(); if (o) { pushUndo(); o.brightness = c.b; o.contrast = c.c; picRerender(o); } }); g.appendChild(b); });
+      corr.appendChild(g); }
+    const rec = document.getElementById('picRecolorMenu');
+    if (rec) { rec.innerHTML = ''; const g = document.createElement('div'); g.className = 'pic-grid';
+      RECOLORS.forEach(([v, label]) => { const b = picPreviewBtn(v ? RECOLOR_FILTERS[v] : '', label); b.addEventListener('click', () => { const o = selImage(); if (o) { pushUndo(); if (v) o.recolor = v; else delete o.recolor; picRerender(o); } }); g.appendChild(b); });
+      rec.appendChild(g); }
+  }
+  const PIC_STYLES = [{}, { picBorder: '#222222', picBorderW: 3 }, { picBorder: '#ffffff', picBorderW: 4, picShadow: '#00000045' }, { picRadius: 14 }, { picRadius: 14, picBorder: '#adb5bd', picBorderW: 2 }, { picShadow: '#00000055' }];
+  function applyPicStyle(st) { const o = selImage(); if (!o) return; pushUndo(); delete o.picBorder; delete o.picBorderW; delete o.picRadius; delete o.picShadow; Object.assign(o, st); picRerender(o); }
+  function buildPicStyleGallery() {
+    const host = document.getElementById('picStyleGallery'); if (!host) return; host.innerHTML = '';
+    PIC_STYLES.forEach((st) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'pic-style-sw'; const im = document.createElement('span'); im.className = 'pic-style-img';
+      if (st.picBorder) im.style.border = `${st.picBorderW || 2}px solid ${st.picBorder}`; if (st.picRadius) im.style.borderRadius = st.picRadius + 'px'; if (st.picShadow) im.style.boxShadow = `2px 2px 5px ${st.picShadow}`;
+      b.appendChild(im); b.addEventListener('click', () => applyPicStyle(st)); host.appendChild(b); });
+  }
+  function buildPicBorderMenu() {
+    buildColorMenu(document.getElementById('picBorderMenu'), {
+      apply: (c) => { const o = selImage(); if (o) { pushUndo(); o.picBorder = c; if (!num(o.picBorderW, 0)) o.picBorderW = 2; picRerender(o); } },
+      noneLabel: '✕ No Border', onNone: () => { const o = selImage(); if (o) { pushUndo(); delete o.picBorder; delete o.picBorderW; picRerender(o); } },
+      weights: true, weight: (w) => { const o = selImage(); if (o) { pushUndo(); if (!o.picBorder) o.picBorder = '#333333'; o.picBorderW = w; picRerender(o); } }, sampleLabel: 'Sample border colour…',
+    });
+  }
+  function picEffects(act) { const o = selImage(); if (!o) return; pushUndo(); if (act === 'shadow') { if (o.picShadow) delete o.picShadow; else o.picShadow = '#00000040'; } else if (act === 'round') { o.picRadius = num(o.picRadius, 0) ? 0 : 14; } else { delete o.picShadow; o.picRadius = 0; } picRerender(o); }
+  function picCaption(act) { const o = selImage(); if (!o) return; pushUndo(); if (act === 'none') o.captionStyle = 'none'; else o.captionStyle = act; if (el.picCaptionText && !o.caption) o.caption = el.picCaptionText.value || 'Caption'; picRerender(o); }
+  function picResetAdjust() { const o = selImage(); if (!o) return; pushUndo(); delete o.brightness; delete o.contrast; delete o.recolor; picRerender(o); setStatus('Picture adjustments cleared.', 'ok'); }
+  // --- Compress Pictures ----------------------------------------------------
+  // Downsample the stored image to a target print resolution. The page renders
+  // at 96 CSS-ppi (so a picture shown at W css-px prints W/96 inches wide);
+  // the kept region needs W·ppi/96 pixels for `ppi` at that print size. PNG /
+  // GIF / WebP keep their format (alpha); anything else re-encodes to JPEG.
+  const picByteLen = (s) => { s = String(s || ''); const i = s.indexOf(','); const b = i >= 0 ? s.slice(i + 1) : s; return Math.floor(b.length * 0.75); };
+  const fmtBytes = (n) => { n = Math.max(0, Math.round(n)); return n >= 1048576 ? (n / 1048576).toFixed(1) + ' MB' : n >= 1024 ? Math.round(n / 1024) + ' KB' : n + ' B'; };
+  function compressOne(o, ppi, bakeCrop) {
+    return new Promise((resolve) => {
+      if (!o || !o.src || o.placeholder) { resolve(0); return; }
+      const before = picByteLen(o.src);
+      const img = new Image();
+      img.onload = () => {
+        const nW = img.naturalWidth, nH = img.naturalHeight;
+        const cr = o.crop || { l: 0, t: 0, r: 0, b: 0 };
+        const hasCrop = !!(num(cr.l, 0) || num(cr.t, 0) || num(cr.r, 0) || num(cr.b, 0));
+        const doBake = bakeCrop && hasCrop;
+        let sx = 0, sy = 0, sw = nW, sh = nH;
+        if (doBake) { sx = Math.round(cr.l * nW); sy = Math.round(cr.t * nH); sw = Math.max(1, Math.round(nW * (1 - cr.l - cr.r))); sh = Math.max(1, Math.round(nH * (1 - cr.t - cr.b))); }
+        const fullDispW = num(o.width, 160);
+        const keepDispW = doBake ? fullDispW * (1 - cr.l - cr.r) : fullDispW;
+        const targetW = Math.max(1, Math.min(sw, Math.round(keepDispW * ppi / 96)));
+        const targetH = Math.max(1, Math.round(sh * (targetW / sw)));
+        const cv = document.createElement('canvas'); cv.width = targetW; cv.height = targetH;
+        const ctx = cv.getContext('2d'); ctx.imageSmoothingEnabled = true; ctx.imageSmoothingQuality = 'high';
+        ctx.drawImage(img, sx, sy, sw, sh, 0, 0, targetW, targetH);
+        const keepAlpha = /^data:image\/(png|gif|webp)/i.test(o.src);
+        const out = keepAlpha ? cv.toDataURL('image/png') : cv.toDataURL('image/jpeg', 0.85);
+        if (picByteLen(out) < before) { o.src = out; o.natW = targetW; o.natH = targetH; if (doBake) { delete o.crop; o.width = Math.max(8, Math.round(keepDispW)); } }
+        resolve(before - picByteLen(o.src));
+      };
+      img.onerror = () => resolve(0);
+      img.src = o.src;
+    });
+  }
+  function compressSel(ppi, bakeCrop) {
+    const imgs = sels.filter((r) => r.kind === 'image' && r.src && !r.placeholder);
+    if (!imgs.length) { setStatus('Select a picture to compress.', ''); return; }
+    pushUndo();
+    Promise.all(imgs.map((o) => compressOne(o, ppi, bakeCrop))).then((saved) => {
+      imgs.forEach((o) => picRerender(o));
+      const total = saved.reduce((a, b) => a + b, 0);
+      setStatus(total > 0 ? `Compressed ${imgs.length} picture${imgs.length > 1 ? 's' : ''} — saved ${fmtBytes(total)}.` : 'Pictures already at or below that resolution.', total > 0 ? 'ok' : '');
+      syncSelUI();
+    });
+  }
+  // --- Swap Pictures --------------------------------------------------------
+  // Exchange the contents (image + adjustments) of two pictures, each keeping
+  // its own frame: position, size, border, caption. Two selected → swap; one
+  // selected → pick the partner by clicking it.
+  let swapPickMode = null;
+  const SWAP_KEYS = ['src', 'natW', 'natH', 'crop', 'flipH', 'flipV', 'brightness', 'contrast', 'recolor', 'placeholder'];
+  function swapContents(a, b) {
+    if (!a || !b || a === b || a.kind !== 'image' || b.kind !== 'image') return;
+    pushUndo();
+    SWAP_KEYS.forEach((k) => { const t = a[k]; a[k] = b[k]; b[k] = t; });
+    picRerender(a); picRerender(b); drawSel();
+    setStatus('Picture contents swapped.', 'ok');
+  }
+  function cancelSwap() { swapPickMode = null; document.body.classList.remove('pf-linking'); }
+  function swapPictures() {
+    const imgs = sels.filter((r) => r.kind === 'image');
+    if (imgs.length === 2) { swapContents(imgs[0], imgs[1]); return; }
+    if (swapPickMode) { cancelSwap(); return; }
+    const one = selImage(); if (!one) { setStatus('Select a picture (or two) to swap.', ''); return; }
+    swapPickMode = one; document.body.classList.add('pf-linking');
+    setStatus('Click another picture to swap contents with (Esc to cancel).', '');
+  }
+  function syncPictureUI() {
+    const o = selImage();
+    if (el.picNone) el.picNone.classList.toggle('hidden', !!o);
+    if (el.picControls) el.picControls.classList.toggle('hidden', !o);
+    if (!o) return;
+    if (el.picW) el.picW.value = Math.round(num(o.width, 160));
+    if (el.picCaptionText) el.picCaptionText.value = o.caption || '';
+  }
+  // Record the natural pixel size of a picture (needed to compute crop aspect).
+  function captureNatSize(o) {
+    if (!o || !o.src) return;
+    const img = new Image();
+    img.onload = () => { o.natW = img.naturalWidth; o.natH = img.naturalHeight; };
+    img.src = o.src;
+  }
+  // --- Interactive crop -----------------------------------------------------
+  const clampF = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+  const round4 = (v) => Math.round(v * 1e4) / 1e4;
+  function imgFilterCss(o) { const parts = []; if (num(o.brightness, 1) !== 1) parts.push(`brightness(${o.brightness})`); if (num(o.contrast, 1) !== 1) parts.push(`contrast(${o.contrast})`); if (RECOLOR_FILTERS[o.recolor]) parts.push(RECOLOR_FILTERS[o.recolor]); return parts.length ? `filter:${parts.join(' ')};` : ''; }
+  let cropTarget = null, cropAnchor = null, cropLayer = null;
+  function startCrop() {
+    const o = selImage(); if (!o) { setStatus('Select a picture to crop.', ''); return; }
+    if (cropTarget) { endCrop(true); return; }
+    if (!num(o.natW, 0) || !num(o.natH, 0)) { captureNatSize(o); setStatus('Picture still loading — try Crop again in a moment.', ''); return; }
+    const cr = o.crop || { l: 0, t: 0, r: 0, b: 0 };
+    const fullW = num(o.width, 160), fullH = fullW * (o.natH / o.natW), sc = num(o.scale, 1);
+    cropAnchor = { fx: o.x - num(cr.l, 0) * fullW * sc, fy: o.y - num(cr.t, 0) * fullH * sc, fullW, fullH, sc, crop: { l: num(cr.l, 0), t: num(cr.t, 0), r: num(cr.r, 0), b: num(cr.b, 0) } };
+    cropTarget = o; document.body.classList.add('cropping');
+    if (el.picCropBtn) el.picCropBtn.classList.add('on');
+    renderCropOverlay();
+    setStatus('Drag the handles to crop — click Crop again or press Enter to apply, Esc to cancel.', '');
+  }
+  function endCrop(apply) {
+    if (!cropTarget) return; const o = cropTarget, a = cropAnchor;
+    if (apply) {
+      pushUndo();
+      o.crop = { l: round4(a.crop.l), t: round4(a.crop.t), r: round4(a.crop.r), b: round4(a.crop.b) };
+      o.x = Math.round(a.fx + o.crop.l * a.fullW * a.sc); o.y = Math.round(a.fy + o.crop.t * a.fullH * a.sc);
+      picRerender(o);
+    }
+    cropTarget = null; cropAnchor = null;
+    if (cropLayer) { cropLayer.remove(); cropLayer = null; }
+    document.body.classList.remove('cropping');
+    if (el.picCropBtn) el.picCropBtn.classList.remove('on');
+    drawSel(); syncSelUI();
+  }
+  function renderCropOverlay() {
+    if (!cropTarget) return; const a = cropAnchor, o = cropTarget;
+    if (cropLayer) cropLayer.remove();
+    cropLayer = document.createElement('div'); cropLayer.className = 'pf-crop-layer';
+    cropLayer.style.cssText = `position:absolute;left:0;top:0;transform:translate(${a.fx}px,${a.fy}px) scale(${a.sc});transform-origin:top left;z-index:60;`;
+    const box = document.createElement('div'); box.style.cssText = `position:absolute;left:0;top:0;width:${a.fullW}px;height:${a.fullH}px;overflow:hidden;`;
+    const img = document.createElement('img'); img.src = o.src; img.style.cssText = `position:absolute;left:0;top:0;width:${a.fullW}px;height:${a.fullH}px;${imgFilterCss(o)}`;
+    box.appendChild(img);
+    const { l, t, r, b } = a.crop; const vw = a.fullW * (1 - l - r), vh = a.fullH * (1 - t - b);
+    const rect = document.createElement('div'); rect.className = 'pf-crop-rect';
+    rect.style.cssText = `position:absolute;left:${l * a.fullW}px;top:${t * a.fullH}px;width:${vw}px;height:${vh}px;`;
+    [['nw', 0, 0], ['n', 0.5, 0], ['ne', 1, 0], ['e', 1, 0.5], ['se', 1, 1], ['s', 0.5, 1], ['sw', 0, 1], ['w', 0, 0.5]].forEach(([d, hx, hy]) => {
+      const h = document.createElement('div'); h.className = 'pf-crop-h'; h.style.left = `calc(${hx * 100}% - 7px)`; h.style.top = `calc(${hy * 100}% - 7px)`;
+      h.addEventListener('pointerdown', (ev) => startCropDrag(ev, d)); rect.appendChild(h);
+    });
+    box.appendChild(rect); cropLayer.appendChild(box); el.stageInner.appendChild(cropLayer);
+  }
+  function startCropDrag(ev, dir) {
+    ev.stopPropagation(); ev.preventDefault(); const a = cropAnchor; if (!a) return;
+    const sx = ev.clientX, sy = ev.clientY, c0 = { ...a.crop };
+    const move = (e) => {
+      const dxl = (e.clientX - sx) / zoom / a.sc / a.fullW, dyl = (e.clientY - sy) / zoom / a.sc / a.fullH;
+      let { l, t, r, b } = c0;
+      if (dir.includes('w')) l = clampF(c0.l + dxl, 0, 1 - c0.r - 0.05);
+      if (dir.includes('e')) r = clampF(c0.r - dxl, 0, 1 - c0.l - 0.05);
+      if (dir.includes('n')) t = clampF(c0.t + dyl, 0, 1 - c0.b - 0.05);
+      if (dir.includes('s')) b = clampF(c0.b - dyl, 0, 1 - c0.t - 0.05);
+      a.crop = { l, t, r, b }; renderCropOverlay();
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+  function resetCrop() { const o = selImage(); if (!o) return; if (cropTarget === o) endCrop(false); pushUndo(); delete o.crop; picRerender(o); syncSelUI(); }
+  function cropToSquare() {
+    const o = selImage(); if (!o) return; if (!num(o.natW, 0) || !num(o.natH, 0)) { captureNatSize(o); return; }
+    const aspect = o.natH / o.natW; pushUndo();
+    // trim the longer axis to a centered square
+    if (aspect > 1) { const cut = (1 - 1 / aspect) / 2; o.crop = { l: 0, r: 0, t: cut, b: cut }; }
+    else { const cut = (1 - aspect) / 2; o.crop = { l: cut, r: cut, t: 0, b: 0 }; }
+    picRerender(o); syncSelUI();
+  }
+  function addShape(shape) {
+    const line = shape === 'line';
+    const bubble = shape === 'speech' || shape === 'thought';
+    addElement({
+      group: 'el', id: uid++, kind: 'shape', shape,
+      x: Math.round(dims.usableWidth / 2 - 90), y: Math.round(dims.usableHeight / 2 - 65),
+      scale: 1, rot: 0, z: 100,
+      w: line ? 220 : bubble ? 200 : 160, h: line ? 12 : bubble ? 130 : 120,
+      fill: line ? 'none' : schemeFill(), stroke: schemeStroke(), strokeW: line ? 3 : 2,
+    });
+  }
+
+  // Decorative accent bar spanning most of the content width (Publisher-style).
+  function addAccentBar(style) {
+    const w = Math.round(dims.usableWidth * 0.9);
+    const x = Math.round((dims.usableWidth - w) / 2);
+    const y = Math.round(dims.usableHeight / 2);
+    if (style === 'line' || style === 'double') {
+      addElement({ group: 'el', id: uid++, kind: 'shape', shape: 'line', x, y, scale: 1, rot: 0, z: 100,
+        w, h: 12, fill: 'none', stroke: schemeStroke(), strokeW: style === 'double' ? 5 : 2 });
+    } else {
+      addElement({ group: 'el', id: uid++, kind: 'shape', shape: 'rect', x, y, scale: 1, rot: 0, z: 100,
+        w, h: style === 'thick' ? 22 : 10, fill: schemeFill(), stroke: 'none', strokeW: 0 });
+    }
+  }
+
+  // Insert a month calendar as a title text + a 7-column table, grouped.
+  function addCalendar() {
+    const now = new Date();
+    const def = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const spec = window.prompt('Calendar month (YYYY-MM):', def);
+    if (spec == null) return;
+    const m = /^(\d{4})-(\d{1,2})$/.exec(String(spec).trim());
+    const year = m ? Number(m[1]) : now.getFullYear();
+    const month = (m ? Math.max(1, Math.min(12, Number(m[2]))) : now.getMonth() + 1) - 1;
+    const first = new Date(year, month, 1);
+    const startDay = first.getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const names = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const weeks = Math.ceil((startDay + daysInMonth) / 7);
+    const rows = weeks + 1; // header row + weeks
+    const cols = 7;
+    const cells = Array.from({ length: rows }, () => Array(cols).fill(''));
+    names.forEach((d, i) => { cells[0][i] = d; });
+    let day = 1;
+    for (let r = 1; r < rows && day <= daysInMonth; r++) {
+      for (let c = 0; c < cols; c++) {
+        if ((r - 1) * 7 + c >= startDay && day <= daysInMonth) cells[r][c] = String(day++);
+      }
+    }
+    const colW = Math.max(48, Math.round((dims.usableWidth * 0.86) / cols));
+    const tblW = colW * cols;
+    const x = Math.round((dims.usableWidth - tblW) / 2), y = Math.round(dims.usableHeight * 0.2);
+    const title = first.toLocaleString('en-US', { month: 'long' }) + ' ' + year;
+    pushUndo();
+    const gid = 'g' + uid++;
+    const els = [
+      { group: 'el', id: uid++, gid, kind: 'text', text: title, x, y, w: tblW, scale: 1, rot: 0, z: 100,
+        fontSize: 22, bold: true, align: 'center', color: '#222222', fontFamily: 'sans' },
+      { group: 'el', id: uid++, gid, kind: 'table', x, y: y + 40, scale: 1, rot: 0, z: 100,
+        rows, cols, cells, colW: Array(cols).fill(colW), header: true, borderColor: schemeStroke(), borderW: 1,
+        headerFill: '#eef1fe', cellPad: 6, fontSize: 13, fontFamily: 'sans', color: '#222222', align: 'center' },
+    ];
+    const pm = curModel();
+    els.forEach((e) => { pm.elements.push(e); el.stageInner.insertBefore(makeEl(e), selLayer); });
+    setSel(els);
+    setStatus(`Inserted a ${title} calendar.`, 'ok');
+  }
+  // Make the selected object a clickable link (renders as an <a> in the PDF).
+  function linkSel() {
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el') { setStatus('Select an object first, then add a link.', ''); return; }
+    const url = window.prompt('Link to (URL) — leave blank to remove:', o.link || 'https://');
+    if (url == null) return;
+    pushUndo(); o.link = url.trim() || undefined; o._node.innerHTML = elHtml(o); requestAnimationFrame(drawSel);
+    setStatus(o.link ? 'Link added — the object is clickable in a digital PDF.' : 'Link removed.', 'ok');
+  }
+  // Tag the selected object with a bookmark name (a jump target in a digital PDF).
+  function bookmarkSel() {
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el') { setStatus('Select an object first, then add a bookmark.', ''); return; }
+    const name = window.prompt('Bookmark name — leave blank to remove:', o.bookmark || '');
+    if (name == null) return;
+    pushUndo(); o.bookmark = name.trim() || undefined; o._node.innerHTML = elHtml(o); requestAnimationFrame(drawSel);
+    setStatus(o.bookmark ? `Bookmark “${o.bookmark}” added.` : 'Bookmark removed.', 'ok');
+  }
+
+  // --- Tables ---
+  function emptyCells(rows, cols) { return Array.from({ length: rows }, () => Array.from({ length: cols }, () => '')); }
+  function addTable(rows, cols) {
+    rows = Math.max(1, Math.min(60, rows || 3));
+    cols = Math.max(1, Math.min(20, cols || 3));
+    addElement({
+      group: 'el', id: uid++, kind: 'table',
+      x: Math.round(dims.usableWidth / 2 - 135), y: Math.round(dims.usableHeight / 2 - 60),
+      scale: 1, rot: 0, z: 100,
+      rows, cols, cells: emptyCells(rows, cols), colW: Array(cols).fill(90),
+      header: true, borderColor: schemeStroke(), borderW: 1, headerFill: '#eef1fe', cellPad: 6,
+      fontSize: 15, fontFamily: 'sans', color: '#222222', align: 'left',
+    });
+  }
+  // Build the Home → Objects dropdowns: a hover grid-picker for tables and a
+  // categorised shape gallery (Publisher-style). Both live in .rdrop menus, so
+  // initDropdowns() already handles open/close/placement.
+  const SHAPE_GALLERY = [
+    { name: 'Lines', shapes: [['line', 'Line'], ['arrow-right', 'Arrow']] },
+    { name: 'Basic Shapes', shapes: [
+      ['rect', 'Rectangle'], ['roundrect', 'Rounded rectangle'], ['ellipse', 'Ellipse'],
+      ['triangle', 'Triangle'], ['righttriangle', 'Right triangle'], ['diamond', 'Diamond'],
+      ['pentagon', 'Pentagon'], ['hexagon', 'Hexagon'], ['octagon', 'Octagon'],
+      ['trapezoid', 'Trapezoid'], ['parallelogram', 'Parallelogram'], ['cross', 'Cross'], ['heart', 'Heart'],
+    ] },
+    { name: 'Block Arrows', shapes: [
+      ['arrow-right', 'Right arrow'], ['arrow-left', 'Left arrow'], ['arrow-up', 'Up arrow'], ['arrow-down', 'Down arrow'],
+    ] },
+    { name: 'Stars & Banners', shapes: [['star4', '4-point star'], ['star', '5-point star'], ['star6', '6-point star']] },
+    { name: 'Callouts', shapes: [['speech', 'Speech bubble'], ['thought', 'Thought bubble']] },
+  ];
+  function shapeIcon(shape) {
+    // A tiny preview drawn by the shared renderer, so gallery icons match output.
+    const line = shape === 'line';
+    return elHtml({ kind: 'shape', shape, w: 26, h: line ? 16 : 22, fill: line ? 'none' : '#dbe4ff', stroke: '#3b4a66', strokeW: line ? 2 : 1.5 });
+  }
+  function buildShapeGallery(hostId) {
+    const host = document.getElementById(hostId || 'shapeGallery'); if (!host) return;
+    host.innerHTML = '';
+    SHAPE_GALLERY.forEach((cat) => {
+      const h = document.createElement('div'); h.className = 'shapegal-cat'; h.textContent = cat.name; host.appendChild(h);
+      const grid = document.createElement('div'); grid.className = 'shapegal-grid';
+      cat.shapes.forEach(([shape, label]) => {
+        const b = document.createElement('button');
+        b.type = 'button'; b.className = 'iconbtn shape-btn'; b.dataset.shape = shape; b.title = label;
+        b.innerHTML = shapeIcon(shape);
+        grid.appendChild(b);
+      });
+      host.appendChild(grid);
+    });
+  }
+  function buildTablePicker(gridId, labelId, moreId) {
+    const grid = document.getElementById(gridId || 'tablepickGrid');
+    const label = document.getElementById(labelId || 'tablepickLabel');
+    const more = document.getElementById(moreId || 'tablepickMore');
+    if (!grid) return;
+    const MAXR = 8, MAXC = 10;
+    grid.style.gridTemplateColumns = `repeat(${MAXC}, 16px)`;
+    grid.innerHTML = '';
+    const cells = [];
+    const paint = (rr, cc) => {
+      cells.forEach((cell) => cell.classList.toggle('on', cell._r <= rr && cell._c <= cc));
+      label.textContent = rr && cc ? `${rr} × ${cc} Table` : 'Insert Table';
+    };
+    for (let r = 1; r <= MAXR; r++) {
+      for (let c = 1; c <= MAXC; c++) {
+        const cell = document.createElement('span'); cell.className = 'tablepick-cell'; cell._r = r; cell._c = c;
+        cell.addEventListener('mouseenter', () => paint(r, c));
+        cell.addEventListener('click', () => { closeObjMenus(); addTable(r, c); });
+        cells.push(cell); grid.appendChild(cell);
+      }
+    }
+    grid.addEventListener('mouseleave', () => paint(0, 0));
+    if (more) more.addEventListener('click', () => {
+      closeObjMenus();
+      const spec = window.prompt('Table size — rows × columns:', '3 x 3');
+      if (spec == null) return;
+      const m = String(spec).match(/(\d+)\s*[x×,]\s*(\d+)/i);
+      if (m) addTable(Number(m[1]), Number(m[2]));
+    });
+  }
+  function closeObjMenus() {
+    document.querySelectorAll('.rdrop-menu').forEach((m) => {
+      m.hidden = true; const b = m.parentElement.querySelector('.rdrop-btn'); if (b) b.setAttribute('aria-expanded', 'false');
+    });
+  }
+  function buildObjectMenus() {
+    buildShapeGallery('shapeGallery');
+    buildShapeGallery('insShapeGallery');
+    buildTablePicker('tablepickGrid', 'tablepickLabel', 'tablepickMore');
+    buildTablePicker('insTablepickGrid', 'insTablepickLabel', 'insTablepickMore');
+    buildPagePartsMenu();
+  }
+
+  // --- QR codes ---
+  // Encode a URL into a module matrix using the shared qrcode-generator lib
+  // (window.qrcode), the same encoder the engine uses — so the editor QR is
+  // byte-identical to a server-generated one.
+  function qrModules(text, ecl) {
+    try {
+      const qr = window.qrcode(0, ['L', 'M', 'Q', 'H'].includes(ecl) ? ecl : 'M');
+      qr.addData(String(text == null ? '' : text));
+      qr.make();
+      const n = qr.getModuleCount(); const mods = [];
+      for (let r = 0; r < n; r++) { const row = []; for (let c = 0; c < n; c++) row.push(qr.isDark(r, c) ? 1 : 0); mods.push(row); }
+      return mods;
+    } catch (_) { return []; }
+  }
+  function addQr() {
+    const url = window.prompt('QR code links to (URL or text):', 'https://');
+    if (url == null) return;
+    const ecl = 'M';
+    addElement({
+      group: 'el', id: uid++, kind: 'qr',
+      x: Math.round(dims.usableWidth / 2 - 70), y: Math.round(dims.usableHeight / 2 - 70),
+      scale: 1, rot: 0, z: 100, w: 140, url: url.trim(), ecl, fg: '#000000', bg: '#ffffff',
+      modules: qrModules(url.trim(), ecl),
+    });
+  }
+  const selQr = () => { const o = sels.length === 1 && sels[0]; return o && o.kind === 'qr' ? o : null; };
+  function reencodeQr(q) { q.modules = qrModules(q.url, q.ecl); q._node.innerHTML = elHtml(q); requestAnimationFrame(drawSel); }
+  // Re-render a QR node in place (colour/size change — no re-encode needed).
+  function qrRender(q) { q._node.innerHTML = elHtml(q); requestAnimationFrame(drawSel); }
+  const QR_ECL_LABEL = { L: 'L — Low', M: 'M — Medium', Q: 'Q — Quartile', H: 'H — High' };
+  function setQrEcl(v) { const q = selQr(); if (!q || !QR_ECL_LABEL[v]) return; pushUndo(); q.ecl = v; reencodeQr(q); syncQrUI(q); }
+  // Colour presets shown in the Styles gallery (same swatch pattern as Picture/WordArt).
+  const QR_STYLES = [
+    { fg: '#000000', bg: '#ffffff' }, { fg: '#1f2937', bg: '#f8fafc' },
+    { fg: '#1d4ed8', bg: '#ffffff' }, { fg: '#047857', bg: '#ffffff' },
+    { fg: '#7c3aed', bg: '#ffffff' }, { fg: '#ffffff', bg: '#111827' },
+  ];
+  function applyQrStyle(st) { const q = selQr(); if (!q) return; pushUndo(); q.fg = st.fg; q.bg = st.bg; qrRender(q); syncQrUI(q); }
+  function buildQrStyleGallery() {
+    const host = document.getElementById('qrStyleGallery'); if (!host) return; host.innerHTML = '';
+    QR_STYLES.forEach((st) => {
+      const b = document.createElement('button'); b.type = 'button'; b.className = 'pic-style-sw'; b.title = 'Apply QR colours';
+      const im = document.createElement('span'); im.className = 'pic-style-img qr-style-img';
+      im.style.background = st.bg; im.style.color = st.fg;
+      b.appendChild(im); b.addEventListener('click', () => applyQrStyle(st)); host.appendChild(b);
+    });
+  }
+  function syncQrUI(one) {
+    if (!el.qrControls) return;
+    const q = one && one.kind === 'qr' ? one : null;
+    el.qrControls.classList.toggle('hidden', !q); if (el.qrNone) el.qrNone.classList.toggle('hidden', !!q);
+    if (!q) return;
+    if (el.qrUrl) el.qrUrl.value = q.url || '';
+    const ecl = QR_ECL_LABEL[q.ecl] ? q.ecl : 'M';
+    if (el.qrEclDropBtn) { const lab = el.qrEclDropBtn.childNodes[el.qrEclDropBtn.childNodes.length - 2]; if (lab) lab.textContent = 'Correction (' + ecl + ') '; }
+    const transparent = q.bg === 'none';
+    if (el.qrFg) el.qrFg.value = /^#/.test(q.fg || '') ? q.fg : '#000000';
+    if (el.qrBg) { el.qrBg.value = /^#/.test(q.bg || '') ? q.bg : '#ffffff'; el.qrBg.disabled = transparent; }
+    if (el.qrTransparent) el.qrTransparent.checked = transparent;
+    if (el.qrW) el.qrW.value = Math.round(num(q.w, 140));
+  }
+  const selTable = () => { const o = sels.length === 1 && sels[0]; return o && o.kind === 'table' ? o : null; };
+  function ensureCells(t) {
+    if (!Array.isArray(t.cells)) t.cells = [];
+    for (let r = 0; r < t.rows; r++) { if (!Array.isArray(t.cells[r])) t.cells[r] = []; for (let c = 0; c < t.cols; c++) if (t.cells[r][c] == null) t.cells[r][c] = ''; }
+  }
+  function redrawTable(t) { t._node.innerHTML = elHtml(t); highlightCells(t); requestAnimationFrame(drawSel); }
+  // Cell-range selection inside a selected table (click a cell, Shift-click to
+  // extend), used by Merge / Split / Diagonals on the Table Layout tab.
+  function onTableCellDown(t, ev) {
+    if (ev.button !== 0) return;
+    if (!(sels.length === 1 && sels[0] === t)) return; // not in cell mode → let the element drag
+    const td = ev.target.closest && ev.target.closest('td'); if (!td) return;
+    ev.stopImmediatePropagation();
+    const r = Number(td.dataset.r), c = Number(td.dataset.c);
+    if (ev.shiftKey && t._sel) { t._sel.r1 = r; t._sel.c1 = c; } else t._sel = { r0: r, c0: c, r1: r, c1: c };
+    highlightCells(t);
+  }
+  function highlightCells(t) {
+    if (!t || !t._node) return; const sel = t._sel;
+    t._node.querySelectorAll('td.cell-sel').forEach((td) => td.classList.remove('cell-sel'));
+    if (!sel) return;
+    const minR = Math.min(sel.r0, sel.r1), maxR = Math.max(sel.r0, sel.r1), minC = Math.min(sel.c0, sel.c1), maxC = Math.max(sel.c0, sel.c1);
+    t._node.querySelectorAll('td[data-r]').forEach((td) => { const r = +td.dataset.r, c = +td.dataset.c; if (r >= minR && r <= maxR && c >= minC && c <= maxC) td.classList.add('cell-sel'); });
+  }
+  function mergeTableCells() {
+    const t = selTable(); if (!t || !t._sel) { setStatus('Click a cell, then Shift-click another, to pick a range to merge.', ''); return; }
+    const s = t._sel; const minR = Math.min(s.r0, s.r1), maxR = Math.max(s.r0, s.r1), minC = Math.min(s.c0, s.c1), maxC = Math.max(s.c0, s.c1);
+    if (minR === maxR && minC === maxC) { setStatus('Select two or more cells to merge (Shift-click a second cell).', ''); return; }
+    pushUndo(); ensureCells(t);
+    t.spans = (t.spans || []).filter((sp) => { const er = sp[0] + sp[2] - 1, ec = sp[1] + sp[3] - 1; return (er < minR || sp[0] > maxR || ec < minC || sp[1] > maxC); });
+    const parts = [];
+    for (let r = minR; r <= maxR; r++) for (let c = minC; c <= maxC; c++) { const v = (t.cells[r] && t.cells[r][c]) || ''; if (v) parts.push(v); if (!(r === minR && c === minC)) t.cells[r][c] = ''; }
+    t.cells[minR][minC] = parts.join(' ');
+    t.spans.push([minR, minC, maxR - minR + 1, maxC - minC + 1]);
+    t._sel = { r0: minR, c0: minC, r1: minR, c1: minC };
+    redrawTable(t); setStatus('Cells merged.', 'ok');
+  }
+  function splitTableCells() {
+    const t = selTable(); if (!t || !t._sel) { setStatus('Click the merged cell to split first.', ''); return; }
+    const r = Math.min(t._sel.r0, t._sel.r1), c = Math.min(t._sel.c0, t._sel.c1);
+    pushUndo();
+    t.spans = (t.spans || []).filter((sp) => !(sp[0] <= r && r < sp[0] + sp[2] && sp[1] <= c && c < sp[1] + sp[3]));
+    redrawTable(t); setStatus('Cell split.', 'ok');
+  }
+  function toggleTableDiagonal() {
+    const t = selTable(); if (!t || !t._sel) { setStatus('Click a cell first, then add a diagonal.', ''); return; }
+    const r = Math.min(t._sel.r0, t._sel.r1), c = Math.min(t._sel.c0, t._sel.c1);
+    pushUndo(); t.diags = t.diags || [];
+    const i = t.diags.findIndex((d) => d[0] === r && d[1] === c);
+    if (i >= 0) t.diags.splice(i, 1); else t.diags.push([r, c]);
+    redrawTable(t);
+  }
+  function tableOp(fn) { const t = selTable(); if (!t) return; pushUndo(); ensureCells(t); fn(t); ensureCells(t); redrawTable(t); syncSelUI(); }
+  function editTableCell(t, ev) {
+    const td = ev.target.closest('td'); if (!td) return;
+    const r = Number(td.dataset.r), c = Number(td.dataset.c);
+    ensureCells(t);
+    td.setAttribute('contenteditable', 'true'); td.focus();
+    // Put the caret at the end of the cell.
+    const sel = window.getSelection(); const range = document.createRange(); range.selectNodeContents(td); range.collapse(false); sel.removeAllRanges(); sel.addRange(range);
+    let committed = false;
+    const done = () => {
+      if (committed) return; committed = true;
+      td.removeAttribute('contenteditable');
+      pushUndo(); t.cells[r][c] = td.innerText.replace(/\n+$/, '');
+      td.removeEventListener('blur', done); td.removeEventListener('keydown', onk);
+      redrawTable(t);
+    };
+    const onk = (e) => { if (e.key === 'Escape' || (e.key === 'Enter' && !e.shiftKey)) { e.preventDefault(); td.blur(); } };
+    td.addEventListener('blur', done); td.addEventListener('keydown', onk);
+  }
+
+  // --- Table Design / Table Layout (two contextual tabs, Publisher-style) ---
+  function tblSet(prop, val) { const t = selTable(); if (!t) return; pushUndo(); t[prop] = val; redrawTable(t); syncSelUI(); }
+  const TABLE_FORMATS = [
+    { name: 'Plain', borderColor: '#333333', borderW: 1, header: false, headerFill: '#f0f0f0', cellFill: 'none' },
+    { name: 'Grid', borderColor: '#495057', borderW: 1, header: true, headerFill: '#e9ecef', cellFill: 'none' },
+    { name: 'Blue', borderColor: '#1c7ed6', borderW: 1, header: true, headerFill: '#d0ebff', cellFill: 'none' },
+    { name: 'Warm', borderColor: '#e8590c', borderW: 1, header: true, headerFill: '#ffe8cc', cellFill: '#fff9f0' },
+    { name: 'Green', borderColor: '#2b8a3e', borderW: 1, header: true, headerFill: '#d3f9d8', cellFill: 'none' },
+    { name: 'Minimal', borderColor: '#adb5bd', borderW: 0.5, header: true, headerFill: '#f8f9fa', cellFill: 'none' },
+  ];
+  function applyTableFormat(fmt) { const t = selTable(); if (!t) return; pushUndo(); Object.assign(t, { borderColor: fmt.borderColor, borderW: fmt.borderW, header: fmt.header, headerFill: fmt.headerFill, cellFill: fmt.cellFill }); redrawTable(t); syncSelUI(); }
+  function buildTableFormatGallery() {
+    const host = document.getElementById('tdFormatGallery'); if (!host) return; host.innerHTML = '';
+    TABLE_FORMATS.forEach((fmt) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'td-fmt-sw'; b.title = fmt.name;
+      b.innerHTML = `<span class="td-fmt-h" style="background:${fmt.header ? fmt.headerFill : '#fff'};border-color:${fmt.borderColor}"></span><span class="td-fmt-b" style="background:${fmt.cellFill === 'none' ? '#fff' : fmt.cellFill};border-color:${fmt.borderColor}"></span>`;
+      b.addEventListener('click', () => applyTableFormat(fmt)); host.appendChild(b); });
+  }
+  function buildTableMenus() {
+    buildColorMenu(document.getElementById('tdFillMenu'), { apply: (c) => tblSet('cellFill', c), noneLabel: '✕ No Fill', onNone: () => tblSet('cellFill', 'none') });
+    buildColorMenu(document.getElementById('tdHeaderFillMenu'), { apply: (c) => tblSet('headerFill', c), noneLabel: '✕ No Fill', onNone: () => tblSet('headerFill', 'none') });
+    buildColorMenu(document.getElementById('tdLineColorMenu'), { apply: (c) => tblSet('borderColor', c), noneLabel: 'Automatic (dark)', onNone: () => tblSet('borderColor', '#333333') });
+  }
+  // Structural edits clear merges/diagonals (their row/col indices would shift).
+  const tblClearSpans = (t) => { t.spans = []; t.diags = []; t._sel = null; };
+  function tblInsRow(where) { tableOp((t) => { ensureCells(t); const row = Array(t.cols).fill(''); if (where === 'above') t.cells.unshift(row); else t.cells.push(row); t.rows++; tblClearSpans(t); }); }
+  function tblInsCol(where) { tableOp((t) => { ensureCells(t); t.cells.forEach((r) => { if (where === 'left') r.unshift(''); else r.push(''); }); if (where === 'left') t.colW.unshift(90); else t.colW.push(90); t.cols++; tblClearSpans(t); }); }
+  function tblDelRow() { tableOp((t) => { if (t.rows > 1) { t.rows--; t.cells.pop(); tblClearSpans(t); } }); }
+  function tblDelCol() { tableOp((t) => { if (t.cols > 1) { t.cols--; t.colW.pop(); t.cells.forEach((r) => r.pop()); tblClearSpans(t); } }); }
+  function syncTableTabsUI() {
+    const t = selTable();
+    if (el.tdNone) el.tdNone.classList.toggle('hidden', !!t);
+    if (el.tdControls) el.tdControls.classList.toggle('hidden', !t);
+    if (el.tlNone) el.tlNone.classList.toggle('hidden', !!t);
+    if (el.tlControls) el.tlControls.classList.toggle('hidden', !t);
+    if (!t) return;
+    if (el.tdBorderW) el.tdBorderW.value = num(t.borderW, 1);
+    if (el.tdHeader) el.tdHeader.checked = !!t.header;
+    document.querySelectorAll('.tbl-align').forEach((b) => b.classList.toggle('on', (t.align || 'left') === b.dataset.talign));
+  }
+
+  // --- Master pages ---
+  function masterPageNo(i) { const skip = Math.max(0, num(master.skipFirst, 0)); if (i < skip) return null; return i - skip + num(master.startAt, 1); }
+  function masterAppliesTo(i) { const n = masterPageNo(i); if (n == null) return false; if (master.applyTo === 'odd') return n % 2 === 1; if (master.applyTo === 'even') return n % 2 === 0; return true; }
+  function renderMasterOverlay() {
+    if (!master.enabled || !master.elements.length || !masterAppliesTo(cur)) return;
+    const no = masterPageNo(cur);
+    master.elements.slice().sort((a, b) => num(a.z, 0) - num(b.z, 0)).forEach((e) => {
+      const shown = e.field === 'pageNumber' ? { ...e, text: String(no) } : e;
+      const node = document.createElement('div'); node.className = 'pf-node pf-master-ov';
+      node.style.transform = `translate(${num(e.x, 0)}px,${num(e.y, 0)}px) rotate(${num(e.rot, 0)}deg) scale(${num(e.scale, 1)})`;
+      node.innerHTML = elHtml(shown);
+      el.stageInner.insertBefore(node, vGuide);
+    });
+  }
+  function updateMasterUI() {
+    if (el.masterBanner) el.masterBanner.hidden = !masterMode;
+    if (el.editMasterBtn) { el.editMasterBtn.classList.toggle('on', masterMode); el.editMasterBtn.textContent = masterMode ? '✓ Editing Master' : '✎ Edit Master Page'; }
+    document.body.classList.toggle('master-editing', masterMode);
+    updateViewButtons();
+  }
+  function enterMaster() {
+    if (masterMode) return;
+    masterModel.elements = master.elements;   // edit the live overlay array
+    masterMode = true; sels = []; updateMasterUI(); renderPage();
+    setStatus('Editing the Master Page — add page numbers, headers, or a frame that repeat on every page in scope.', 'ok');
+  }
+  function exitMaster() {
+    if (!masterMode) return;
+    master.elements = masterModel.elements;   // keep the source array in sync
+    masterMode = false; sels = []; updateMasterUI(); renderPage();
+    setStatus('Back to the book. The master overlay shows on every page in scope.', 'ok');
+  }
+  const toggleMaster = () => (masterMode ? exitMaster() : enterMaster());
+  // Position within the page margins for a header/footer/page-number field.
+  // `pos` is a two-letter code: [t|b][l|c|r] (top/bottom × left/center/right).
+  function marginPos(pos) {
+    const code = typeof pos === 'string' ? pos : 'bc';
+    const top = code[0] === 't';
+    const col = code[1];
+    const w = 140;
+    const y = top ? 22 : Math.round(dims.usableHeight - 34);
+    let x, align;
+    if (col === 'l') { x = 0; align = 'left'; }
+    else if (col === 'r') { x = Math.round(dims.usableWidth - w); align = 'right'; }
+    else { x = Math.round(dims.usableWidth / 2 - w / 2); align = 'center'; }
+    return { x, y, w, align };
+  }
+  function insertPageNumber(pos) {
+    if (!masterMode) enterMaster();
+    const p = marginPos(pos || 'bc');
+    addElement({ group: 'el', id: uid++, kind: 'text', field: 'pageNumber', text: '#',
+      x: p.x, y: p.y, scale: 1, rot: 0, z: 200, fontSize: 13, color: '#333333', align: p.align, w: p.w, fontFamily: 'sans' });
+    setStatus('Page-number field added to the master — it prints each page’s number. Move it where you want.', 'ok');
+  }
+  // A repeating header/footer lives on the master page (edits enter master mode).
+  function addMasterText(which) {
+    if (!masterMode) enterMaster();
+    const footer = which === 'footer';
+    const p = marginPos(footer ? 'bc' : 'tc');
+    addElement({ group: 'el', id: uid++, kind: 'text', text: footer ? 'Footer' : 'Header',
+      x: 0, y: p.y, scale: 1, rot: 0, z: 190, fontSize: 13, color: '#555555', align: 'center', w: dims.usableWidth, fontFamily: 'sans' });
+    setStatus(`${footer ? 'Footer' : 'Header'} added to the master — it repeats on every page. Double-click to edit the text.`, 'ok');
+  }
+  function syncMasterScopeUI() {
+    if (el.masterApplyTo) el.masterApplyTo.value = master.applyTo || 'all';
+    if (el.masterSkip) el.masterSkip.value = num(master.skipFirst, 1);
+    if (el.masterStart) el.masterStart.value = num(master.startAt, 1);
+    if (el.masterEnabled) el.masterEnabled.checked = master.enabled !== false;
+  }
+  // Sent to the server so the overlay applies on export/preview/package. Strips
+  // the live DOM node (`_node`) so the payload is JSON-serializable.
+  function masterForSend() {
+    if (!master.enabled || !master.elements.length) return null;
+    return { enabled: true, applyTo: master.applyTo || 'all', skipFirst: num(master.skipFirst, 0), startAt: num(master.startAt, 1),
+      elements: master.elements.map(({ _node, ...e }) => e) };
+  }
+
+  // --- Insert: WordArt, Symbol, Date, AI Art ---
+  const WORDART = [
+    { name: 'Bold Outline', style: { fontSize: 56, bold: true, color: '#ffd43b', fontFamily: 'sans', textStroke: '#222222', textStrokeW: 2 } },
+    { name: 'Candy Shadow', style: { fontSize: 52, bold: true, color: '#e64980', fontFamily: 'hand', textShadow: '#00000033' } },
+    { name: 'Sky Pop', style: { fontSize: 54, bold: true, color: '#4dabf7', fontFamily: 'sans', textStroke: '#1c3d5a', textStrokeW: 1.5 } },
+    { name: 'Classic Serif', style: { fontSize: 48, bold: true, color: '#222222', fontFamily: 'serif' } },
+    { name: 'Ghost Outline', style: { fontSize: 58, bold: true, color: '#ffffff', fontFamily: 'sans', textStroke: '#222222', textStrokeW: 2 } },
+    { name: 'Sunset', style: { fontSize: 54, bold: true, color: '#ff922b', fontFamily: 'hand', textStroke: '#7a3b00', textStrokeW: 1.5, textShadow: '#00000030' } },
+  ];
+  const SYMBOLS = '★ ☆ ♥ ● ○ ◆ ■ ▲ ► ◄ ▼ → ← ↑ ↓ ⇒ ✓ ✗ ✚ ✦ ✪ ☀ ☁ ☂ ☺ ☹ ♪ ♫ ✏ ✂ ⚑ ❄ ☘ ⬤ ⬛ ⬜ 🔢 🎯'.split(' ');
+  function addWordArt(preset) {
+    if (!preset) return;
+    addElement({ group: 'el', id: uid++, kind: 'text', x: Math.round(dims.usableWidth / 2 - 160), y: Math.round(dims.usableHeight * 0.3),
+      scale: 1, rot: 0, z: 110, text: 'Your Title', align: 'center', w: 320, lineHeight: 1.15, ...preset.style });
+  }
+  // Apply a WordArt preset's style to the SELECTED text box (the Insert-tab
+  // WordArt inserts a new box; this restyles the current one, like Publisher).
+  function applyWordArt(preset) {
+    const o = selText(); if (!o || !preset) return; pushUndo();
+    Object.assign(o, preset.style);
+    o._node.innerHTML = elHtml(o); drawSel(); syncFontUI(o);
+  }
+  function setTextOutline(color) {
+    const o = selText(); if (!o) return; pushUndo();
+    o.textStroke = color; if (!num(o.textStrokeW, 0)) o.textStrokeW = 1.5;
+    o._node.innerHTML = elHtml(o); drawSel();
+  }
+  function buildWordArtGallery() {
+    const host = document.getElementById('wordartGallery'); if (!host) return;
+    host.innerHTML = '';
+    WORDART.forEach((w) => {
+      const s = w.style;
+      const b = document.createElement('button'); b.type = 'button'; b.className = 'wordart-swatch'; b.title = w.name; b.textContent = 'A';
+      b.style.color = s.color || '#222'; b.style.fontFamily = fontStackFor(s.fontFamily || 'sans'); b.style.fontWeight = s.bold ? '700' : '400';
+      if (s.textStroke) b.style.webkitTextStroke = `1px ${s.textStroke}`;
+      b.addEventListener('click', () => applyWordArt(w));
+      host.appendChild(b);
+    });
+  }
+  // --- Text Box tab: colour palettes (Text Fill / Text Outline), Fit, Margins ---
+  const STD_COLORS = ['#000000', '#444444', '#666666', '#888888', '#bbbbbb', '#ffffff', '#c0392b', '#e74c3c', '#e67e22', '#f1c40f', '#f9e79f', '#2ecc71', '#27ae60', '#16a085', '#3498db', '#2980b9', '#6741d9', '#9c36b5', '#d6336c', '#f783ac'];
+  const schemePalette = () => { const s = activeScheme ? activeScheme.colors.slice() : ['#3b5bdb', '#e64980', '#f59f00', '#2b8a3e']; return ['#000000', '#ffffff', ...s, '#495057', '#adb5bd']; };
+  function buildColorMenu(host, opts) {
+    if (!host) return; host.innerHTML = '';
+    const sec = (t) => { const h = document.createElement('div'); h.className = 'color-sec'; h.textContent = t; host.appendChild(h); };
+    const rowOf = (colors) => { const r = document.createElement('div'); r.className = 'color-row'; colors.forEach((c) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'color-sw rdrop-item'; b.style.background = c; b.title = c; b.addEventListener('click', () => opts.apply(c)); r.appendChild(b); }); host.appendChild(r); };
+    const sep = () => { const d = document.createElement('div'); d.className = 'rdrop-sep'; host.appendChild(d); };
+    const opt = (label, fn) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'rdrop-item color-opt'; b.textContent = label; b.addEventListener('click', fn); host.appendChild(b); };
+    sec('Scheme Colors'); rowOf(schemePalette());
+    sec('Standard Colors'); rowOf(STD_COLORS);
+    sep();
+    opt(opts.noneLabel, opts.onNone);
+    opt('More Colors…', () => pickMore(opts.apply));
+    if (window.EyeDropper) opt(opts.sampleLabel || 'Sample colour…', () => sampleColor(opts.apply));
+    if (opts.weights) {
+      sep(); sec('Weight');
+      const r = document.createElement('div'); r.className = 'color-row wt-row';
+      [['Thin', 0.75], ['Med', 1.5], ['Bold', 3]].forEach(([l, w]) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'rdrop-item wt-btn'; b.textContent = l; b.addEventListener('click', () => opts.weight(w)); r.appendChild(b); });
+      host.appendChild(r);
+    }
+  }
+  function pickMore(apply) {
+    const inp = document.createElement('input'); inp.type = 'color'; inp.value = '#333333'; inp.style.cssText = 'position:fixed;opacity:0;pointer-events:none;'; document.body.appendChild(inp);
+    inp.addEventListener('input', () => apply(inp.value));
+    inp.addEventListener('change', () => setTimeout(() => inp.remove(), 200));
+    inp.click();
+  }
+  async function sampleColor(apply) { try { const r = await new window.EyeDropper().open(); if (r && r.sRGBHex) apply(r.sRGBHex); } catch (_) { /* cancelled */ } }
+  function clearOutline() { const o = selText(); if (!o) return; pushUndo(); delete o.textStroke; delete o.textStrokeW; o._node.innerHTML = elHtml(o); drawSel(); }
+  function buildFillOutlineMenus() {
+    buildColorMenu(document.getElementById('tbFillMenu'), { apply: (c) => applyTextPropU('color', c), noneLabel: '✕ No Fill', onNone: () => applyTextPropU('color', 'none') });
+    buildColorMenu(document.getElementById('tbOutlineMenu'), {
+      apply: (c) => setTextOutline(c), noneLabel: '✕ No Outline', onNone: clearOutline, sampleLabel: 'Sample line colour…',
+      weights: true, weight: (w) => { const o = selText(); if (o) { pushUndo(); if (!o.textStroke) o.textStroke = '#222222'; o.textStrokeW = w; o._node.innerHTML = elHtml(o); drawSel(); } },
+    });
+  }
+  // Text Fit: grow the box to the text's natural width, or shrink the font to fit.
+  function applyTextFit(mode) {
+    const o = selText(); if (!o || !o._node) return; const inner = o._node.firstElementChild; if (!inner) return;
+    if (mode === 'none') { o._fit = 'none'; return; }
+    pushUndo();
+    const prev = inner.style.whiteSpace; inner.style.whiteSpace = 'nowrap';
+    if (mode === 'shrink') {
+      let fs = num(o.fontSize, 24);
+      for (let i = 0; i < 60 && inner.scrollWidth > num(o.w, 240) && fs > 6; i++) { fs -= 1; inner.style.fontSize = fs + 'px'; }
+      inner.style.whiteSpace = prev; o.fontSize = fs; o._node.innerHTML = elHtml(o); drawSel(); syncFontUI(o);
+    } else {
+      const nat = Math.min(dims.usableWidth, Math.ceil(inner.scrollWidth) + 6);
+      inner.style.whiteSpace = prev; o.w = Math.max(40, nat); o._node.innerHTML = elHtml(o); drawSel(); syncSelUI();
+    }
+  }
+  function setTextMargins(preset) {
+    const o = selText(); if (!o) return;
+    const map = { none: 0, narrow: 0.04, moderate: 0.06, wide: 0.1 };
+    let inch = map[preset];
+    if (preset === 'custom') { const v = parseFloat(window.prompt('Text box inset margin (inches):', String(num(o.pad, 0) / 96))); if (!isFinite(v)) return; inch = Math.max(0, Math.min(0.6, v)); }
+    if (inch == null) return;
+    pushUndo(); o.pad = Math.round(inch * 96); o._node.innerHTML = elHtml(o); drawSel();
+  }
+  // --- Shape Format tab (2nd contextual ribbon: frame fill/outline + shapes) ---
+  const sfSel = () => (sels.length === 1 ? sels[0] : null);
+  const sfApplicable = () => { const o = sfSel(); return !!(o && (o.kind === 'text' || o.kind === 'shape')); };
+  const sfRerender = (o) => { o._node.innerHTML = elHtml(o); drawSel(); };
+  // Fill / outline route to the text-box frame (boxFill/boxStroke) or the shape.
+  function shapeFill(c) { const o = sfSel(); if (!o) return; pushUndo(); if (o.kind === 'text') o.boxFill = c; else o.fill = c; sfRerender(o); syncSelUI(); }
+  function shapeFillNone() { const o = sfSel(); if (!o) return; pushUndo(); if (o.kind === 'text') o.boxFill = 'none'; else o.fill = 'none'; sfRerender(o); syncSelUI(); }
+  function shapeOutline(c) { const o = sfSel(); if (!o) return; pushUndo(); if (o.kind === 'text') { o.boxStroke = c; if (!num(o.boxStrokeW, 0)) o.boxStrokeW = 1.5; } else { o.stroke = c; if (!num(o.strokeW, 0)) o.strokeW = 2; } sfRerender(o); syncSelUI(); }
+  function shapeOutlineNone() { const o = sfSel(); if (!o) return; pushUndo(); if (o.kind === 'text') { delete o.boxStroke; delete o.boxStrokeW; } else o.stroke = 'none'; sfRerender(o); syncSelUI(); }
+  function shapeOutlineWeight(w) { const o = sfSel(); if (!o) return; pushUndo(); if (o.kind === 'text') { if (!o.boxStroke) o.boxStroke = '#333333'; o.boxStrokeW = w; } else { if (!o.stroke || o.stroke === 'none') o.stroke = '#333333'; o.strokeW = w; } sfRerender(o); }
+  function shapeEffects(act) { const o = sfSel(); if (!o) return; pushUndo(); if (act === 'shadow') { if (o.kind === 'text') { if (o.boxShadow) delete o.boxShadow; else o.boxShadow = '#00000033'; } else { o.shadow = !o.shadow; } } else { delete o.boxShadow; o.shadow = false; } sfRerender(o); }
+  function buildShapeStyleMenus() {
+    buildColorMenu(document.getElementById('sfFillMenu'), { apply: shapeFill, noneLabel: '✕ No Fill', onNone: shapeFillNone });
+    buildColorMenu(document.getElementById('sfOutlineMenu'), { apply: shapeOutline, noneLabel: '✕ No Outline', onNone: shapeOutlineNone, weights: true, weight: shapeOutlineWeight, sampleLabel: 'Sample line colour…' });
+  }
+  const SHAPE_STYLES = [
+    { fill: 'none', stroke: '#222222', w: 1.5 }, { fill: 'none', stroke: '#1c7ed6', w: 1.5 }, { fill: 'none', stroke: '#e8590c', w: 1.5 },
+    { fill: '#f1f3f5', stroke: '#adb5bd', w: 1 }, { fill: '#fff3bf', stroke: '#f59f00', w: 1.5 }, { fill: '#d0ebff', stroke: '#1c7ed6', w: 1.5 },
+  ];
+  function applyShapeStyle(st) {
+    const o = sfSel(); if (!o) return; pushUndo();
+    if (o.kind === 'text') { o.boxFill = st.fill; o.boxStroke = st.stroke; o.boxStrokeW = st.w; if (!num(o.pad, 0)) o.pad = 6; }
+    else { o.fill = st.fill; o.stroke = st.stroke; o.strokeW = st.w; }
+    sfRerender(o); syncSelUI();
+  }
+  function buildShapeStyleGallery() {
+    const host = document.getElementById('sfStyleGallery'); if (!host) return; host.innerHTML = '';
+    SHAPE_STYLES.forEach((st) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'sf-style-sw'; b.title = 'Apply this style'; b.style.background = st.fill === 'none' ? '#ffffff' : st.fill; b.style.border = `2px solid ${st.stroke}`; b.addEventListener('click', () => applyShapeStyle(st)); host.appendChild(b); });
+  }
+  function buildSfShapeGallery() {
+    const host = document.getElementById('sfShapeGallery'); if (!host) return; host.innerHTML = '';
+    const flat = []; SHAPE_GALLERY.forEach((c) => c.shapes.forEach((s) => flat.push(s)));
+    flat.slice(0, 6).forEach(([shape, label]) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'iconbtn shape-btn'; b.title = 'Insert ' + label; b.innerHTML = shapeIcon(shape); b.addEventListener('click', () => addShape(shape)); host.appendChild(b); });
+  }
+  function buildSfChangeMenu() {
+    const host = document.getElementById('sfChangeMenu'); if (!host) return; host.innerHTML = '';
+    [['rect', '▭ Rectangle'], ['round', '▢ Rounded Rectangle'], ['ellipse', '◯ Ellipse']].forEach(([act, label]) => { const b = document.createElement('button'); b.type = 'button'; b.className = 'rdrop-item'; b.textContent = label; b.addEventListener('click', () => changeShape(act)); host.appendChild(b); });
+  }
+  function changeShape(act) {
+    const o = sfSel(); if (!o) return; pushUndo();
+    if (o.kind === 'text') { o.boxRadius = act === 'round' ? 16 : act === 'ellipse' ? 999 : 0; if (!o.boxStroke && (!o.boxFill || o.boxFill === 'none')) { o.boxStroke = '#333333'; o.boxStrokeW = 1.5; o.pad = o.pad || 6; } }
+    else { o.shape = act === 'round' ? 'roundrect' : act === 'ellipse' ? 'ellipse' : 'rect'; }
+    sfRerender(o);
+  }
+  function addSymbol(sym) {
+    if (!sym) return;
+    const o = selText();
+    if (o) { pushUndo(); o.text = (o.text || '') + sym; o._node.innerHTML = elHtml(o); drawSel(); }
+    else addElement({ group: 'el', id: uid++, kind: 'text', x: Math.round(dims.usableWidth / 2 - 30), y: Math.round(dims.usableHeight / 2 - 30), scale: 1, rot: 0, z: 100, text: sym, fontSize: 48, color: '#222222', align: 'center', w: 60 });
+  }
+  function insertDate() {
+    addElement({ group: 'el', id: uid++, kind: 'text', x: Math.round(dims.usableWidth / 2 - 90), y: Math.round(dims.usableHeight / 2), scale: 1, rot: 0, z: 100, text: new Date().toLocaleDateString(), fontSize: 22, color: '#222222', align: 'center', w: 180 });
+  }
+  function openAiArt() { window.open('aiart.html', '_blank'); }
+  function populateInsertMenus() {
+    if (el.wordArt.options.length <= 1) WORDART.forEach((w, i) => { const o = document.createElement('option'); o.value = String(i); o.textContent = w.name; el.wordArt.appendChild(o); });
+    if (el.symbolPick.options.length <= 1) SYMBOLS.forEach((s) => { const o = document.createElement('option'); o.value = s; o.textContent = s; el.symbolPick.appendChild(o); });
+  }
+
+  // --- Page Design: color schemes ---
+  const SCHEMES = [
+    { id: 'office', name: 'Office', colors: ['#3b5bdb', '#e64980', '#f59f00', '#2b8a3e'] },
+    { id: 'ocean', name: 'Ocean', colors: ['#1864ab', '#1c7ed6', '#22b8cf', '#0ca678'] },
+    { id: 'candy', name: 'Candy', colors: ['#d6336c', '#e64980', '#f783ac', '#f59f00'] },
+    { id: 'forest', name: 'Forest', colors: ['#2b8a3e', '#37b24d', '#94d82d', '#66a80f'] },
+    { id: 'sunset', name: 'Sunset', colors: ['#e8590c', '#f76707', '#f59f00', '#e03131'] },
+    { id: 'grape', name: 'Grape', colors: ['#6741d9', '#9c36b5', '#ae3ec9', '#7048e8'] },
+    { id: 'slate', name: 'Slate', colors: ['#212529', '#495057', '#1c7ed6', '#adb5bd'] },
+    { id: 'classic', name: 'Classic', colors: ['#000000', '#444444', '#888888', '#bbbbbb'] },
+  ];
+  let activeScheme = null;
+  const schemeFill = () => (activeScheme ? activeScheme.colors[2] : '#ffd43b');
+  const schemeStroke = () => (activeScheme ? activeScheme.colors[0] : '#222222');
+  function renderSchemes() {
+    if (!el.schemeGallery || el.schemeGallery.childElementCount) return;
+    SCHEMES.forEach((s) => {
+      const chip = document.createElement('button'); chip.className = 'scheme-chip'; chip.dataset.id = s.id; chip.title = s.name;
+      chip.innerHTML = `<span class="scheme-sw">${s.colors.map((c) => `<i style="background:${c}"></i>`).join('')}</span><span class="scheme-nm">${s.name}</span>`;
+      chip.addEventListener('click', () => applyScheme(s));
+      el.schemeGallery.appendChild(chip);
+    });
+  }
+  function applyScheme(s) {
+    activeScheme = s;
+    buildFillOutlineMenus(); buildShapeStyleMenus(); buildTableMenus(); buildPicBorderMenu(); // refresh scheme swatches
+    pageModels.forEach((pm) => { pm._borderColor = s.colors[0]; });
+    // Immediate feedback: recolor whatever's selected to the scheme.
+    if (sels.length) {
+      pushUndo();
+      sels.forEach((r) => {
+        if (r.kind === 'shape') { r.fill = s.colors[2]; r.stroke = s.colors[0]; r._node.innerHTML = elHtml(r); }
+        else if (r.kind === 'text') { r.color = s.colors[0]; r._node.innerHTML = elHtml(r); }
+      });
+      drawSel(); syncSelUI();
+    }
+    [...el.schemeGallery.children].forEach((c) => c.classList.toggle('active', c.dataset.id === s.id));
+    setStatus(`“${s.name}” scheme active — new shapes and page frames use these colors (frames show on export). Selected items were recolored.`, 'ok');
+  }
+
+  // --- Page Design: rename / margin guide ---
+  function renamePagePrompt() {
+    const pm = pageModels[cur]; if (!pm) return;
+    const name = window.prompt('Name this page (shown in the page list):', pm.name || labelFor(pm));
+    if (name === null) return;
+    pm.name = name.trim() || null; buildPageList();
+  }
+  function applyMarginGuide() {
+    if (!el.stageInner) return;
+    let g = el.stageInner.querySelector('.pf-margin-guide');
+    if (el.marginGuide.checked) {
+      if (!g) { g = document.createElement('div'); g.className = 'pf-margin-guide'; el.stageInner.appendChild(g); }
+      const inset = marginInset; // set by the Margins dropdown
+      g.style.cssText = `position:absolute;left:${inset}px;top:${inset}px;right:${inset}px;bottom:${inset}px;border:1px dashed #ff2d9b;pointer-events:none;z-index:5;`;
+    } else if (g) { g.remove(); }
+  }
+  // Page Design → Layout: guide dropdown actions and margin presets.
+  function addGuide(axis) {
+    const g = ensureGuides(curModel()); if (!g) return;
+    pushUndo();
+    if (axis === 'v') g.v.push(Math.round(dims.usableWidth / 2)); else g.h.push(Math.round(dims.usableHeight / 2));
+    renderUserGuides();
+    setStatus('Guide added — drag it to position, double-click to remove.', 'ok');
+  }
+  function clearGuides() {
+    const g = ensureGuides(curModel()); if (!g || (!g.v.length && !g.h.length)) return;
+    pushUndo(); g.v = []; g.h = []; renderUserGuides();
+    setStatus('Guides cleared.', 'ok');
+  }
+  function setMargins(preset) {
+    const map = { wide: 96, moderate: 48, narrow: 24, none: 0 };
+    if (preset === 'custom') {
+      const v = window.prompt('Margin (inches):', (marginInset / PX_PER_IN).toFixed(2));
+      if (v == null) return; const n = Number(v); if (!Number.isFinite(n)) return;
+      marginInset = Math.max(0, Math.round(n * PX_PER_IN));
+    } else if (map[preset] != null) marginInset = map[preset];
+    if (el.marginGuide) el.marginGuide.checked = true;
+    applyMarginGuide();
+    setStatus(`Margin guide set to ${(marginInset / PX_PER_IN).toFixed(2)}″.`, 'ok');
+  }
+  // Reposition (and, if needed, scale) items so they sit inside the current
+  // margin box — the pink guide when it's on, else the whole usable page. The
+  // group's relative layout and aspect ratio are preserved; it's re-centred in
+  // the box. `selOnly` fits just the current selection; otherwise the whole
+  // page. Pinned pieces (grid) and free objects move together.
+  function fitToMargins(selOnly) {
+    const inset = (el.marginGuide && el.marginGuide.checked) ? marginInset : 0;
+    const tx = inset, ty = inset, tw = dims.usableWidth - inset * 2, th = dims.usableHeight - inset * 2;
+    if (tw <= 4 || th <= 4) { setStatus('Margins leave no room to fit into.', 'err'); return; }
+    let refs = (selOnly && sels.length ? sels.slice() : allRefs())
+      .filter((r) => r._node && !r.locked && !(r.group === 'piece' && r.hidden));
+    if (!refs.length) { setStatus(selOnly ? 'Select objects to fit.' : 'Nothing on this page to fit.', ''); return; }
+    // Combined bounding box in page coordinates.
+    const bs = refs.map((r) => ({ r, b: box(r) }));
+    const gx = Math.min(...bs.map((o) => o.b.x)), gy = Math.min(...bs.map((o) => o.b.y));
+    const gw = Math.max(...bs.map((o) => o.b.x + o.b.w)) - gx;
+    const gh = Math.max(...bs.map((o) => o.b.y + o.b.h)) - gy;
+    if (gw <= 0 || gh <= 0) return;
+    const s = Math.min(tw / gw, th / gh);        // scale to fit (shrinks or grows)
+    const ox = tx + (tw - gw * s) / 2, oy = ty + (th - gh * s) / 2; // centre in box
+    pushUndo();
+    bs.forEach(({ r, b }) => {
+      setScale(r, num(r.scale, 1) * s);
+      moveTo(r, Math.round(ox + (b.x - gx) * s), Math.round(oy + (b.y - gy) * s));
+    });
+    drawSel();
+    const pct = Math.round(s * 100);
+    setStatus(`Fit ${selOnly ? 'selection' : 'page'} within the margins${pct !== 100 ? ` (scaled to ${pct}%)` : ''}.`, 'ok');
+  }
+  function applyShapeProp(prop, val) { const o = sels.length === 1 && sels[0]; if (!o || o.kind !== 'shape') return; o[prop] = val; o._node.innerHTML = elHtml(o); drawSel(); }
+  // W/H from the measure panel: intrinsic size per kind.
+  function setElSize(prop, val) {
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el') return; pushUndo();
+    if (prop === 'w') { if (o.kind === 'image') o.width = Math.max(8, val); else o.w = Math.max(8, val); }
+    else if (o.kind === 'shape') o.h = Math.max(4, val);
+    o._node.innerHTML = elHtml(o); drawSel(); syncSelUI();
+  }
+
+  // --- group / clipboard extras / select all ---
+  function groupSel() { if (sels.length < 2) return; pushUndo(); const gid = 'g' + uid++; sels.forEach((r) => { r.gid = gid; }); syncSelUI(); }
+  function ungroupSel() { if (!sels.some((r) => r.gid)) return; pushUndo(); sels.forEach((r) => { delete r.gid; }); syncSelUI(); }
+  function cutSel() { copySel(); deleteSel(); }
+  function selectAll() { setSel(allRefs().filter((r) => !r.locked)); }
+
+  // --- marquee (rubber-band) selection ---
+  function startMarquee(ev, additive, clickRef) {
+    hideCtx();
+    const base = additive ? sels.slice() : []; // shift-drag adds to the selection
+    const r = el.stageInner.getBoundingClientRect();
+    const sx = (ev.clientX - r.left) / zoom, sy = (ev.clientY - r.top) / zoom;
+    const mq = document.createElement('div'); mq.className = 'pf-marquee'; mq.style.display = 'none';
+    el.stageInner.appendChild(mq);
+    let rect = null;
+    const move = (e) => {
+      const px = (e.clientX - r.left) / zoom, py = (e.clientY - r.top) / zoom;
+      rect = { x: Math.min(sx, px), y: Math.min(sy, py), w: Math.abs(px - sx), h: Math.abs(py - sy) };
+      if (rect.w > 3 || rect.h > 3) {
+        mq.style.display = '';
+        mq.style.left = rect.x + 'px'; mq.style.top = rect.y + 'px'; mq.style.width = rect.w + 'px'; mq.style.height = rect.h + 'px';
+      }
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up);
+      mq.remove();
+      if (rect && (rect.w > 3 || rect.h > 3)) {
+        const hit = allRefs().filter((rf) => {
+          if (rf.group !== 'el' || rf.locked || !rf._node) return false; // free objects only, not protected puzzle pieces
+          const b = box(rf);
+          return b.x < rect.x + rect.w && b.x + b.w > rect.x && b.y < rect.y + rect.h && b.y + b.h > rect.y;
+        });
+        const merged = base.slice();
+        expandGroups(hit).forEach((rf) => { if (!merged.includes(rf)) merged.push(rf); });
+        setSel(merged);
+      } else if (clickRef) {
+        // A plain click (no drag) where we suppressed the object's own handler.
+        // Additive: toggle it in/out of the current selection; plain: select it.
+        if (additive) setSel(base.includes(clickRef) ? base.filter((r) => r !== clickRef) : expandGroups(base.concat([clickRef])));
+        else setSel(expandGroups([clickRef]));
+      } else setSel(base); // click on empty stage: clear (or keep, if additive)
+    };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  }
+
+  // --- right-click context menu ---
+  let ctxEl = null;
+  function hideCtx() { if (ctxEl) { ctxEl.remove(); ctxEl = null; } }
+  function showCtx(ev) {
+    ev.preventDefault(); hideCtx();
+    const one = sels.length === 1 ? sels[0] : null;
+    const hasEl = sels.some((r) => r.group === 'el');
+    const items = [];
+    if (sels.length) {
+      if (hasEl) items.push({ label: 'Cut', fn: cutSel }, { label: 'Copy', fn: copySel });
+      else items.push({ label: 'Copy', fn: copySel });
+    }
+    if (clipboard.length) items.push({ label: 'Paste', fn: paste });
+    if (one && one.group === 'el') items.push({ label: 'Duplicate', fn: duplicate });
+    if (hasEl) items.push({ label: 'Delete', fn: deleteSel });
+    if (items.length) items.push('-');
+    if (one && one.group === 'el') items.push({ label: 'Bring to front', fn: () => reorder('front') }, { label: 'Send to back', fn: () => reorder('back') }, '-');
+    if (sels.length >= 2) items.push({ label: 'Group', fn: groupSel });
+    if (sels.some((r) => r.gid)) items.push({ label: 'Ungroup', fn: ungroupSel });
+    if (one) items.push({ label: one.locked ? 'Unlock' : 'Lock', fn: toggleLock });
+    if (one && one.group === 'piece') items.push({ label: 'Hide piece', fn: hideComp });
+    if (canBreakApart()) { if (items.length && items[items.length - 1] !== '-') items.push('-'); items.push({ label: '✂ Break apart puzzle', fn: breakApartPuzzle }); }
+    // Fit-to-margins: pull the page's items (or just the selection) inside the
+    // current margin box. Available whenever the page has something to arrange.
+    if (!masterMode && allRefs().some((r) => r._node && !r.locked)) {
+      if (items.length && items[items.length - 1] !== '-') items.push('-');
+      if (sels.length) items.push({ label: '⤢ Fit selection to margins', fn: () => fitToMargins(true) });
+      items.push({ label: '⤢ Fit page to margins', fn: () => fitToMargins(false) });
+    }
+    if (!items.length) return;
+    ctxEl = document.createElement('div'); ctxEl.className = 'pf-ctx';
+    items.forEach((it) => {
+      if (it === '-') { const s = document.createElement('div'); s.className = 'pf-ctx-sep'; ctxEl.appendChild(s); return; }
+      const b = document.createElement('button'); b.textContent = it.label;
+      b.addEventListener('click', () => { hideCtx(); it.fn(); });
+      ctxEl.appendChild(b);
+    });
+    document.body.appendChild(ctxEl);
+    const mw = ctxEl.offsetWidth, mh = ctxEl.offsetHeight;
+    ctxEl.style.left = Math.min(ev.clientX, window.innerWidth - mw - 8) + 'px';
+    ctxEl.style.top = Math.min(ev.clientY, window.innerHeight - mh - 8) + 'px';
+  }
+  function editText(ref) {
+    // A linked text box edits the whole chain's text through its head box.
+    if (ref.chainId && chainBoxes(ref.chainId).length > 1) { editFlow(ref.chainId); return; }
+    const bx = ref._node.querySelector('.pf-textbox'); bx.setAttribute('contenteditable', 'true'); bx.focus(); pushUndo();
+    const done = () => { bx.removeAttribute('contenteditable'); ref.text = bx.innerText; bx.removeEventListener('blur', done); };
+    bx.addEventListener('blur', done);
+  }
+
+  // --- linked text boxes (Publisher-style flow) -----------------------------
+  // A chain is a set of text boxes sharing a `chainId`, ordered by `chainOrder`.
+  // The head (order 0) holds the authoritative full text in `flowText`; every
+  // box's `.text` is the visible slice, recomputed by reflow. Non-tail boxes
+  // carry a fixed `flowH` so overflow spills into the next box; the tail is
+  // auto-height. Chains are keyed by scalars (no element-id pointers) so they
+  // survive the recipe round-trip. `.text` + `flowH` per box give the exported
+  // PDF identical flow with no server-side measurement.
+  let flowSeq = 1;
+  let linkPickMode = null; // source box while picking a link target
+  const chainBoxes = (cid) => curModel().elements
+    .filter((e) => e.kind === 'text' && e.chainId === cid)
+    .sort((a, b) => num(a.chainOrder, 0) - num(b.chainOrder, 0));
+  function splitToFit(b, text) {
+    const bx = b._node && b._node.querySelector('.pf-textbox');
+    const cap = num(b.flowH, 0);
+    if (!bx || !cap) return { head: text, tail: '' };
+    const measure = (s) => { bx.textContent = s; return bx.scrollHeight; };
+    if (measure(text) <= cap + 1) return { head: text, tail: '' };
+    const toks = text.split(/(\s+)/); // keep whitespace so slices rejoin exactly
+    let lo = 1, hi = toks.length, best = 1;
+    while (lo <= hi) { const mid = (lo + hi) >> 1; if (measure(toks.slice(0, mid).join('')) <= cap + 1) { best = mid; lo = mid + 1; } else hi = mid - 1; }
+    return { head: toks.slice(0, best).join(''), tail: toks.slice(best).join('') };
+  }
+  function reflowChain(cid) {
+    const boxes = chainBoxes(cid); if (!boxes.length) return;
+    let rest = boxes[0].flowText || '';
+    boxes.forEach((b, i) => {
+      if (i === boxes.length - 1) { b.text = rest; rest = ''; }
+      else { const s = splitToFit(b, rest); b.text = s.head; rest = s.tail; }
+      b._node.innerHTML = elHtml(b);
+    });
+    // Overflow indicator: text beyond the (auto-height) tail is rare, but a
+    // non-tail with too-small flowH could still clip — flag the tail if content
+    // exceeds its box.
+    const tail = boxes[boxes.length - 1];
+    boxes.forEach((b) => b._node.classList.remove('pf-overflow'));
+    const tb = tail._node.querySelector('.pf-textbox');
+    if (num(tail.flowH, 0) && tb && tb.scrollHeight > tb.clientHeight + 1) tail._node.classList.add('pf-overflow');
+    requestAnimationFrame(drawSel);
+  }
+  // Freeze non-tail heights (so they can overflow) and collapse a 1-box chain
+  // back to a plain auto box, then reflow.
+  function normalizeAndReflow(cid) {
+    const boxes = chainBoxes(cid);
+    if (boxes.length < 2) {
+      const b = boxes[0];
+      if (b) { delete b.chainId; delete b.chainOrder; delete b.flowText; delete b.flowH; b._node.innerHTML = elHtml(b); requestAnimationFrame(drawSel); }
+      return;
+    }
+    boxes.forEach((b, i) => { b.chainOrder = i; if (i < boxes.length - 1) { if (!num(b.flowH, 0)) b.flowH = Math.max(24, Math.round(b._node.offsetHeight / num(b.scale, 1))); } else delete b.flowH; });
+    reflowChain(cid);
+  }
+  function editFlow(cid) {
+    const boxes = chainBoxes(cid); const head = boxes[0]; if (!head) return;
+    const bx = head._node.querySelector('.pf-textbox'); if (!bx) return;
+    pushUndo();
+    bx.style.height = 'auto'; bx.style.overflow = 'visible'; // unclip while editing
+    bx.textContent = head.flowText || '';
+    bx.setAttribute('contenteditable', 'true'); bx.focus();
+    const done = () => { bx.removeAttribute('contenteditable'); head.flowText = bx.innerText; bx.removeEventListener('blur', done); reflowChain(cid); };
+    bx.addEventListener('blur', done);
+  }
+  function startCreateLink() {
+    const o = selText(); if (!o) { setStatus('Select a text box first, then Create Link.', ''); return; }
+    if (linkPickMode) { cancelLink(); return; }
+    linkPickMode = o; document.body.classList.add('pf-linking');
+    setStatus('Click another text box to flow the overflow into (Esc to cancel).', '');
+  }
+  function cancelLink() { linkPickMode = null; document.body.classList.remove('pf-linking'); }
+  function finishLink(tgt) {
+    const src = linkPickMode; cancelLink(); if (!src || tgt === src) return;
+    if (tgt.kind !== 'text') { setStatus('Links can only flow into another text box.', ''); return; }
+    if (tgt.chainId) { setStatus('That text box is already part of a link chain.', ''); return; }
+    pushUndo();
+    let cid = src.chainId;
+    if (!cid) { cid = 'flow' + (flowSeq++); src.chainId = cid; src.chainOrder = 0; src.flowText = src.text || ''; }
+    const boxes = chainBoxes(cid);
+    const maxOrd = boxes.reduce((m, b) => Math.max(m, num(b.chainOrder, 0)), 0);
+    tgt.chainId = cid; tgt.chainOrder = maxOrd + 1;
+    const head = chainBoxes(cid)[0];
+    if (tgt.text) head.flowText = (head.flowText || '') + (head.flowText ? '\n' : '') + tgt.text;
+    normalizeAndReflow(cid); setSel([src]); setStatus('Text boxes linked — drag the bottom edge to size the flow region.', 'ok');
+  }
+  function breakLink() {
+    const o = selText(); if (!o || !o.chainId) { setStatus('This text box isn’t linked.', ''); return; }
+    pushUndo();
+    const cid = o.chainId; const boxes = chainBoxes(cid); const idx = boxes.indexOf(o);
+    const before = boxes.slice(0, idx + 1), after = boxes.slice(idx + 1);
+    // Downstream boxes become a fresh chain (slices rejoin exactly, join('')).
+    if (after.length) { const ncid = 'flow' + (flowSeq++); after.forEach((b, i) => { b.chainId = ncid; b.chainOrder = i; }); after[0].flowText = after.map((b) => b.text).join(''); normalizeAndReflow(ncid); }
+    before[0].flowText = before.map((b) => b.text).join(''); normalizeAndReflow(cid);
+    syncSelUI(); setStatus('Link broken.', 'ok');
+  }
+  function flowNav(dir) {
+    const o = selText(); if (!o || !o.chainId) return;
+    const boxes = chainBoxes(o.chainId); const t = boxes[boxes.indexOf(o) + (dir > 0 ? 1 : -1)];
+    if (t) setSel([t]);
+  }
+  function applyTextProp(prop, val) { const o = sels.length === 1 && sels[0]; if (!o || o.kind !== 'text') return; o[prop] = val; o._node.innerHTML = elHtml(o); drawSel(); syncFontUI(o); }
+  const applyTextPropU = (prop, val) => { const o = sels.length === 1 && sels[0]; if (o && o.kind === 'text') { pushUndo(); applyTextProp(prop, val); } };
+  const selText = () => { const o = sels.length === 1 && sels[0]; return o && o.kind === 'text' ? o : null; };
+  // --- Home: font & paragraph tools ---
+  function fontStep(delta) { const o = selText(); if (!o) return; applyTextPropU('fontSize', Math.max(6, Math.min(200, num(o.fontSize, 24) + delta))); }
+  function changeCase() {
+    const o = selText(); if (!o) return; const t = String(o.text || '');
+    const upper = t.toUpperCase(), lower = t.toLowerCase();
+    const title = t.replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+    // Cycle UPPER → lower → Title; anything mixed starts the cycle at UPPER.
+    const next = t === upper ? lower : t === lower ? title : t === title ? upper : upper;
+    applyTextPropU('text', next);
+  }
+  function clearTextFmt() {
+    const o = selText(); if (!o) return; pushUndo();
+    Object.assign(o, { fontFamily: 'sans', fontSize: 24, color: '#222222', bold: false, italic: false, underline: false, align: 'left', lineHeight: 1.25 });
+    o._node.innerHTML = elHtml(o); drawSel(); syncFontUI(o);
+  }
+  // --- Format Painter: copy an object's look, apply to the next one clicked ---
+  let painter = null;
+  const TEXT_STYLE = ['fontFamily', 'fontSize', 'color', 'bold', 'italic', 'underline', 'align', 'lineHeight'];
+  const SHAPE_STYLE = ['fill', 'stroke', 'strokeW'];
+  function togglePainter() {
+    if (painter) { painter = null; el.fmtPainter.classList.remove('on'); return; }
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el' || o.kind === 'image') { setStatus('Select a text box or shape first, then Format Painter.', 'err'); return; }
+    const keys = o.kind === 'text' ? TEXT_STYLE : SHAPE_STYLE;
+    painter = { kind: o.kind, style: {} }; keys.forEach((k) => { painter.style[k] = o[k]; });
+    el.fmtPainter.classList.add('on'); setStatus('Format Painter armed — click a ' + o.kind + ' to apply the look.', 'busy');
+  }
+  function applyPainter(ref) {
+    if (!painter || !ref || ref.kind !== painter.kind) return false;
+    pushUndo(); Object.assign(ref, painter.style); ref._node.innerHTML = elHtml(ref);
+    painter = null; el.fmtPainter.classList.remove('on'); setStatus('Look applied.', 'ok'); return true;
+  }
+  // --- Find & Replace (across every page's text objects) ---
+  function openFindReplace() { if (el.main.hidden) return; el.frStatus.textContent = ''; el.frModal.hidden = false; el.frFind.focus(); }
+  function closeFindReplace() { el.frModal.hidden = true; }
+  function doReplaceAll() {
+    const find = el.frFind.value; if (!find) { el.frStatus.textContent = 'Enter text to find.'; el.frStatus.className = 'pf-pub-status err'; return; }
+    const re = new RegExp(find.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), el.frCase.checked ? 'g' : 'gi');
+    const repl = el.frReplace.value;
+    let count = 0; const pagesTouched = new Set();
+    pushUndo(); // undo covers the current page; other pages update in memory
+    pageModels.forEach((pm, pi) => {
+      pm.elements.forEach((e) => {
+        if (e.kind === 'text' && typeof e.text === 'string') {
+          const m = e.text.match(re);
+          if (m) { count += m.length; e.text = e.text.replace(re, repl); pagesTouched.add(pi); }
+        }
+      });
+    });
+    if (count) { renderPage(); el.frStatus.textContent = `Replaced ${count} occurrence${count !== 1 ? 's' : ''} across ${pagesTouched.size} page${pagesTouched.size !== 1 ? 's' : ''}.`; el.frStatus.className = 'pf-pub-status ok'; }
+    else { el.frStatus.textContent = 'No matches found.'; el.frStatus.className = 'pf-pub-status'; }
+  }
+  function duplicate() { const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'el') return; pushUndo(); const { _node, ...c } = o; c.id = uid++; c.x = num(o.x, 0) + 16; c.y = num(o.y, 0) + 16; c.z = num(o.z, 100) + 1; delete c.chainId; delete c.chainOrder; delete c.flowText; delete c.flowH; curModel().elements.push(c); el.stageInner.insertBefore(makeEl(c), selLayer); setSel([c]); }
+  function copySel() { clipboard = sels.filter((r) => r.group === 'el').map((r) => { const { _node, ...c } = r; return c; }); }
+  function paste() { if (!clipboard.length) return; pushUndo(); const made = []; clipboard.forEach((c) => { const e = { ...c, group: 'el', id: uid++, x: num(c.x, 0) + 16, y: num(c.y, 0) + 16, z: num(c.z, 100) + 1 }; curModel().elements.push(e); el.stageInner.insertBefore(makeEl(e), selLayer); made.push(e); }); setSel(made); }
+  function deleteSel() {
+    const els = sels.filter((r) => r.group === 'el'); if (!els.length) return; pushUndo();
+    const arr = curModel().elements;
+    const affected = new Set(els.map((r) => r.chainId).filter(Boolean));
+    els.forEach((r) => { const i = arr.indexOf(r); if (i >= 0) arr.splice(i, 1); if (r._node) r._node.remove(); });
+    setSel([]);
+    affected.forEach((cid) => normalizeAndReflow(cid)); // heal / collapse broken chains
+  }
+  function hideComp() {
+    const o = sels.length === 1 && sels[0]; if (!o || o.group !== 'piece') return;
+    pushUndo(); o.hidden = true; setSel([]);
+    // On content pages pieces sit in document flow, so hiding one reflows the
+    // rest (matching the PDF, which drops hidden pieces). Re-render so the
+    // remaining pieces' measured bases — and thus their selection boxes — track
+    // their new positions instead of pointing at where they used to be.
+    renderPage();
+  }
+  function resetSize() { if (!sels.length) return; pushUndo(); sels.forEach((r) => { setScale(r, 1); setRot(r, 0); }); drawSel(); syncSelUI(); }
+  function nudge(dx, dy) { if (!sels.length) return; sels.forEach((r) => { if (!r.locked) { const b = box(r); moveTo(r, b.x + dx, b.y + dy); } }); drawSel(); syncSelUI(); }
+  function setMeasure(prop, val) { const o = sels.length === 1 && sels[0]; if (!o) return; pushUndo(); const b = box(o); if (prop === 'x') moveTo(o, val, b.y); else if (prop === 'y') moveTo(o, b.x, val); else if (prop === 'scale') setScale(o, val); else if (prop === 'rot') setRot(o, val); drawSel(); syncSelUI(); }
+
+  function resetLayout() { pushUndo(); const pm = pageModels[cur]; pm.comps.forEach((c) => { c.hidden = false; c.dx = 0; c.dy = 0; c.scale = 1; c.rot = 0; c.locked = false; }); pm.elements = []; renderPage(); }
+  function setBorder() { pushUndo(); pageModels[cur]._border = el.border.value; renderPage(); }
+  // Draw the page border as a live SVG overlay using the engine's shared
+  // renderer (window.PFDecor), so what's on screen matches the printed frame.
+  // CSS `background` value for a page's background spec (mirrors backgroundCss
+  // in engine/export.js so the editor and PDF match).
+  function pageBgCss(bg) {
+    if (!bg || !bg.type || bg.type === 'none') return '';
+    const hex = (c, d) => (/^#[0-9a-fA-F]{3,8}$/.test(c || '') ? c : d);
+    if (bg.type === 'solid') return hex(bg.color, '#ffffff');
+    if (bg.type === 'gradient') { const a = Number.isFinite(Number(bg.angle)) ? Math.round(Number(bg.angle)) % 360 : 180; return `linear-gradient(${a}deg, ${hex(bg.color, '#ffffff')}, ${hex(bg.color2, '#dddddd')})`; }
+    return '';
+  }
+  function curBg() { const pm = curModel(); if (!pm) return null; if (!pm._bg) pm._bg = { type: 'none', color: '#ffffff', color2: '#dddddd', angle: 180 }; return pm._bg; }
+  function setBgType(type) { const pm = curModel(); if (!pm) return; pushUndo(); curBg().type = type; renderPage(); syncBgUI(); setStatus(type === 'none' ? 'Page background cleared.' : `Page background: ${type}.`, 'ok'); }
+  function setBgProp(k, v) { const pm = curModel(); if (!pm || !pm._bg) return; pushUndo(); pm._bg[k] = v; el.stageInner.style.background = pageBgCss(pm._bg); }
+  function syncBgUI() {
+    const bg = curModel() && curModel()._bg; const type = (bg && bg.type) || 'none';
+    if (el.bgColors) el.bgColors.style.display = type === 'none' ? 'none' : 'grid';
+    if (el.bgColor2Field) el.bgColor2Field.style.display = type === 'gradient' ? '' : 'none';
+    if (el.bgAngleField) el.bgAngleField.style.display = type === 'gradient' ? '' : 'none';
+    if (bg) { if (el.bgColor) el.bgColor.value = bg.color || '#ffffff'; if (el.bgColor2) el.bgColor2.value = bg.color2 || '#dddddd'; if (el.bgAngle) el.bgAngle.value = bg.angle != null ? bg.angle : 180; }
+    // Reflect the active fill on the menu's type buttons.
+    document.querySelectorAll('#bgDrop .bg-type').forEach((b) => b.classList.toggle('on', b.dataset.bg === type));
+  }
+  function renderBorderFrame(pm) {
+    const style = pm && pm._border;
+    if (!style || style === 'none' || !(window.PFDecor && window.PFDecor.frameSvg)) return;
+    const color = pm._borderColor || (bookConfig && bookConfig.borderColor) || '#333333';
+    const svg = window.PFDecor.frameSvg(style, dims.usableWidth, dims.usableHeight, { color });
+    if (!svg) return;
+    const fr = document.createElement('div'); fr.className = 'pf-frame'; fr.innerHTML = svg;
+    el.stageInner.appendChild(fr);
+  }
+  async function reroll() {
+    const pm = pageModels[cur];
+    if (!pm || pm.role !== 'content' || pm.src == null) { setStatus('Only puzzle pages can be rerolled.', 'err'); return; }
+    if (pm.activity) { setStatus('Activity pages have no puzzle to reroll.', 'err'); return; }
+    el.reroll.disabled = true; setStatus('Rerolling…', 'busy');
+    try {
+      const res = await fetch('/api/book/reroll', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ bookId, index: pm.src }) });
+      const data = await res.json(); if (!res.ok) throw new Error(data.error || 'Reroll failed');
+      const pm = pageModels[cur]; const fresh = buildComps(data.components || []); const byKey = {}; pm.comps.forEach((c) => (byKey[c.key] = c));
+      pm.style = data.style || pm.style; pm.comps = fresh.map((f) => { const old = byKey[f.key]; return old ? { ...f, dx: old.dx, dy: old.dy, scale: old.scale, rot: old.rot, hidden: old.hidden, locked: old.locked } : f; });
+      renderPage(); setStatus('Rerolled.', 'ok');
+    } catch (err) { setStatus(err.message, 'err'); } finally { el.reroll.disabled = false; }
+  }
+  function selectPage(i) { if (masterMode) exitMaster(); if (i === cur) return; cur = i; renderPage(); }
+
+  // --- serialize ---
+  const round2 = (n) => Math.round(num(n, 0) * 100) / 100;
+  // A page with no moved/hidden pieces and no overlays renders faithfully from
+  // the original template — export it as passthrough (no layout), which is
+  // pixel-perfect and avoids any measurement drift on matter pages.
+  function isPristine(pm) {
+    if (pm.elements && pm.elements.length) return false;
+    return pm.comps.every((c) => !c.dx && !c.dy && c.scale === 1 && !c.rot && !c.hidden && !c.locked);
+  }
+  function pageStateOf(pm) {
+    const st = {};
+    if (!isPristine(pm)) {
+      const matter = isMatterPage(pm);
+      const comp = {};
+      pm.comps.forEach((c) => {
+        const o = { dx: Math.round(c.dx), dy: Math.round(c.dy), scale: round2(c.scale), rot: round2(c.rot), hidden: c.hidden, locked: c.locked };
+        if (c.gid) o.gid = c.gid;
+        // Matter pieces carry their measured page anchor so the server can pin
+        // them absolutely (it has no DOM to measure with).
+        if (matter) { o.ax = Math.round(c.baseX); o.ay = Math.round(c.baseY); o.aw = Math.round(c.baseW); }
+        comp[c.key] = o;
+      });
+      const elements = pm.elements.map((e) => ({
+        kind: e.kind, x: Math.round(e.x), y: Math.round(e.y), scale: round2(e.scale), rot: round2(e.rot), z: e.z,
+        text: e.text, fontSize: e.fontSize, color: e.color, align: e.align, w: e.w,
+        fontFamily: e.fontFamily, bold: e.bold, italic: e.italic, underline: e.underline, lineHeight: e.lineHeight,
+        textStroke: e.textStroke, textStrokeW: e.textStrokeW, textShadow: e.textShadow,
+        columns: e.columns, pad: e.pad, numStyle: e.numStyle, ligatures: e.ligatures, dropCap: e.dropCap, hyphens: e.hyphens,
+        stySet: e.stySet, swash: e.swash, styAlt: e.styAlt, contextual: e.contextual,
+        chainId: e.chainId, chainOrder: e.chainOrder, flowText: e.flowText, flowH: e.flowH,
+        boxFill: e.boxFill, boxStroke: e.boxStroke, boxStrokeW: e.boxStrokeW, boxRadius: e.boxRadius, boxShadow: e.boxShadow,
+        src: e.src, width: e.width, flipH: e.flipH, flipV: e.flipV, placeholder: e.placeholder || undefined,
+        brightness: e.brightness, contrast: e.contrast, recolor: e.recolor, picBorder: e.picBorder, picBorderW: e.picBorderW, picRadius: e.picRadius, picShadow: e.picShadow, caption: e.caption, captionStyle: e.captionStyle,
+        crop: e.crop, natW: e.natW, natH: e.natH,
+        link: e.link || undefined, bookmark: e.bookmark || undefined,
+        shape: e.shape, h: e.h, fill: e.fill, stroke: e.stroke, strokeW: e.strokeW,
+        rows: e.rows, cols: e.cols, cells: e.cells, colW: e.colW, header: e.header,
+        borderColor: e.borderColor, borderW: e.borderW, headerFill: e.headerFill, cellPad: e.cellPad, cellFill: e.cellFill,
+        spans: e.spans, diags: e.diags,
+        url: e.url, ecl: e.ecl, fg: e.fg, bg: e.bg, modules: e.modules,
+        behind: e.behind || undefined, field: e.field || undefined,
+        gid: e.gid,
+      }));
+      st.layout = { comp, elements };
+    }
+    if (pm._border) st.border = pm._border;
+    if (pm._borderColor) st.borderColor = pm._borderColor;
+    if (pm._bg && pm._bg.type && pm._bg.type !== 'none') st.bg = pm._bg;
+    if (pm.guides && (pm.guides.v.length || pm.guides.h.length)) st.guides = { v: pm.guides.v.slice(), h: pm.guides.h.slice() };
+    return st;
+  }
+  // Per-page arrangement for export/recipe: keeps the final page order, marks
+  // inserted blanks, and references each real page's original book index (src).
+  const buildPagePlan = () => pageModels.map((pm) => {
+    const state = pageStateOf(pm);
+    if (pm.blank) return { role: 'blank', state };
+    if (pm.role === 'content') {
+      // Editor-inserted puzzle: the plan carries the puzzle object (the server
+      // re-splits it for export) plus a render cache (type/title/style/pieces)
+      // so a saved recipe can rebuild the page offline without a src.
+      if (pm.puzzle) return { role: 'content', puzzle: pm.puzzle, state,
+        page: { type: pm.type, title: pm.title, style: pm.style, components: pm.comps.map((c) => ({ kind: c.kind, html: c.html })) } };
+      return { role: 'content', src: pm.src, state };
+    }
+    if (pm.role === 'frontmatter' || pm.role === 'backmatter') return { role: pm.role, matterKind: pm.matterKind, state };
+    if (pm.role === 'answerkey') return { role: 'answerkey', akIndex: pm.akIndex || 0, state };
+    return { role: pm.role, state }; // title
+  });
+  function buildRecipe() { const book = { ...(bookConfig || {}) }; delete book.seed; delete book.pageState; delete book.puzzleforgeBook; const m = masterForSend(); if (m) book.master = m; else delete book.master; return { recipeVersion: 2, kind: 'book', book, seed, pagePlan: buildPagePlan() }; }
+  function save() { downloadBlob(new Blob([JSON.stringify(buildRecipe(), null, 2)], { type: 'application/json' }), slug((bookConfig && bookConfig.title) || 'book') + '-book.json'); setStatus('Recipe saved (with layout).', 'ok'); }
+
+  // --- Autosave ---------------------------------------------------------
+  // A book opened from the Team library is a TEAM book: it lives in the
+  // workspace and its edits save back there (no personal copy is made). A book
+  // from My Books (currentLibId) saves locally. A brand-new book seeds a local
+  // copy. "Save to my library" forks a team book into a personal one.
+  const isTeamBook = () => !currentLibId && !!workspaceId;
+  const setSaveState = (txt, cls) => { if (el.saveState) { el.saveState.textContent = txt || ''; el.saveState.className = 'save-state' + (cls ? ' ' + cls : ''); } };
+  async function persistLibrary(recipe, json) {
+    if (!window.PFLibrary) return;
+    if (!currentLibId) currentLibId = PFLibrary.newId();
+    const meta = PFLibrary.metaFromRecipe(recipe);
+    try { await PFLibrary.put({ id: currentLibId, ...meta, recipe }); lastSavedJson = json; setSaveState('All changes saved', 'ok'); }
+    catch (_) { setSaveState('Autosave failed (storage full?)', 'err'); }
+  }
+  async function persistTeam(recipe, json) {
+    try { await PFWorkspace.shareBook(workspaceId, recipe, me.name); lastSavedJson = json; setSaveState('Saved to team', 'ok'); }
+    catch (_) { setSaveState('Team autosave failed — is the workspace up?', 'err'); }
+  }
+  // Cheap change detection: rebuild the recipe and compare to the last saved
+  // JSON, so ANY edit is captured without wiring every mutation.
+  function autosaveTick() {
+    if (!bookOpen || el.main.hidden || detached) return;
+    let recipe, json;
+    try { recipe = buildRecipe(); json = JSON.stringify(recipe); } catch (_) { return; }
+    if (json === lastSavedJson) return;
+    setSaveState('Saving…', 'busy');
+    if (isTeamBook() && wsEnabled) persistTeam(recipe, json);
+    else if (window.PFLibrary) persistLibrary(recipe, json);
+  }
+  function startAutosave() {
+    bookOpen = true;
+    let recipe = null, json = null;
+    try { recipe = buildRecipe(); json = JSON.stringify(recipe); } catch (_) { /* */ }
+    lastSavedJson = json;
+    if (currentLibId) setSaveState('All changes saved', 'ok');
+    else if (isTeamBook()) setSaveState('Team book — edits save to the team', 'ok');
+    else if (recipe && window.PFLibrary) persistLibrary(recipe, json);   // brand-new book → seed My Books
+    else setSaveState('Autosaves as you edit', '');
+    if (!startAutosave._timer) startAutosave._timer = setInterval(autosaveTick, 4000);
+  }
+  // Fork the current (team) book into a personal copy in My Books.
+  async function saveToMyLibrary() {
+    if (!bookOpen || !window.PFLibrary) return;
+    let recipe, json;
+    try { recipe = buildRecipe(); json = JSON.stringify(recipe); } catch (_) { return; }
+    const wasTeam = !!workspaceId;
+    currentLibId = PFLibrary.newId();
+    try { await PFLibrary.put({ id: currentLibId, ...PFLibrary.metaFromRecipe(recipe), recipe }); }
+    catch (_) { currentLibId = null; setStatus('Could not save to My Books (browser storage full?).', 'err'); return; }
+    if (wasTeam && wsEnabled) { try { await PFWorkspace.addComment(workspaceId, { author: me.name, role: me.role, text: `📋 ${me.name} saved a personal copy of this book.` }); } catch (_) { /* */ } }
+    workspaceId = null; detached = false; lastSavedJson = json;
+    setSaveState('All changes saved', 'ok'); setWsStatus();
+    setStatus(wasTeam ? 'Saved a personal copy to My Books — you’re now editing your own copy; the team copy is unchanged.' : 'Saved to My Books.', 'ok');
+  }
+  async function exportPdf() {
+    setStatus('Rendering PDF…', 'busy'); el.exportPdf.disabled = true;
+    try { const body = { ...(bookId ? { bookId } : { config: bookConfig }), pagePlan: buildPagePlan(), master: masterForSend(), fonts: usedCustomFontsForSend() };
+      const res = await fetch('/api/book/pdf', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      if (!res.ok) { const d = await res.json().catch(() => ({})); throw new Error(d.error || 'Export failed'); }
+      downloadBlob(await res.blob(), slug((bookConfig && bookConfig.title) || 'book') + '.pdf'); setStatus('PDF exported.', 'ok');
+    } catch (err) { setStatus(err.message, 'err'); } finally { el.exportPdf.disabled = false; }
+  }
+  function downloadBlob(blob, name) { const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove(); setTimeout(() => URL.revokeObjectURL(url), 1000); }
+
+  // --- Publish flow (pre-flight + KDP package) ------------------------------
+  const bookBody = () => ({ ...(bookId ? { bookId } : { config: bookConfig }), pagePlan: buildPagePlan(), master: masterForSend(), fonts: usedCustomFontsForSend() });
+  function openPublish() { if (el.main.hidden) return; refreshCoverState(); el.pubModal.hidden = false; }
+  function closePublish() { el.pubModal.hidden = true; }
+  const bookTitle = () => (bookConfig && bookConfig.title) || '';
+  function savedCover() { try { return JSON.parse(localStorage.getItem('pf_cover') || 'null'); } catch (_) { return null; } }
+  function refreshCoverState() {
+    const cover = savedCover();
+    if (cover) {
+      el.pubCoverStatus.textContent = `✓ Using your Cover Builder design${cover.title ? ` (“${cover.title}”)` : ''}. Trim & spine are matched to this book automatically.`;
+      el.pubCoverStatus.className = 'pf-cover-status ok';
+      el.pubClearCover.hidden = false; el.pubSimpleCover.hidden = true;
+    } else {
+      el.pubCoverStatus.textContent = 'No custom cover yet — a simple cover is generated from your title and the colors below. Or design one in the Cover Builder.';
+      el.pubCoverStatus.className = 'pf-cover-status';
+      el.pubClearCover.hidden = true; el.pubSimpleCover.hidden = false;
+    }
+  }
+  function openCoverBuilder() {
+    const seed = { title: bookTitle(), subtitle: (bookConfig && bookConfig.subtitle) || '', author: (bookConfig && bookConfig.author) || '',
+      trimSize: (bookConfig && bookConfig.trimSize) || '', pageCount: pageModels.length, blurb: el.pubDesc.value || '' };
+    try { localStorage.setItem('pf_cover_seed', JSON.stringify(seed)); } catch (_) { /* */ }
+    window.open('cover.html', '_blank');
+    el.pubCoverStatus.textContent = 'Design your cover in the new tab, click “Use for this book”, then come back — it’ll be picked up here.';
+    el.pubCoverStatus.className = 'pf-cover-status busy';
+  }
+  function clearCover() { try { localStorage.removeItem('pf_cover'); } catch (_) { /* */ } refreshCoverState(); }
+  function gatherMeta() {
+    return { description: el.pubDesc.value, keywords: el.pubKeywords.value, categories: el.pubCategories.value, readingAge: el.pubAge.value,
+      listPrice: el.pubPrice.value, paper: el.pubPaper.value, aiText: el.pubAiText.checked, aiImages: el.pubAiImages.checked,
+      language: (bookConfig && bookConfig.language) || (el.revLanguage && el.revLanguage.value) || 'en' };
+  }
+  const gatherCover = () => ({ bgColor: el.pubCoverBg.value, textColor: el.pubCoverText.value, paper: el.pubPaper.value, blurb: el.pubDesc.value });
+  const setPubStatus = (node, text, kind) => { node.textContent = text || ''; node.className = 'pf-pub-status' + (kind ? ' ' + kind : ''); };
+
+  // --- Review tab: spelling / thesaurus / word count / language ---
+  function openReview(title, sub) {
+    if (!el.revModal) return;
+    el.revTitle.textContent = title; el.revSub.textContent = sub || ''; el.revBody.innerHTML = '';
+    el.revModal.hidden = false;
+  }
+  function closeReview() { if (el.revModal) el.revModal.hidden = true; }
+  async function runSpelling() {
+    if (el.main.hidden) return;
+    openReview('Spelling & grammar', 'Checking every text box you’ve added (titles, matter, labels). Puzzle grids and clues are skipped.');
+    el.revBody.innerHTML = '<div class="rep-note">Proofreading…</div>';
+    try {
+      const r = await fetch('/api/book/proofread', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(bookBody()) });
+      const data = await r.json();
+      if (!r.ok) { el.revBody.innerHTML = `<div class="rep-note err">${escHtml(data.error || 'Proofread failed.')}</div>`; return; }
+      const iss = data.issues || [];
+      if (data.note && !iss.length) { el.revBody.innerHTML = `<div class="rep-note">${escHtml(data.note)}</div>`; return; }
+      if (!iss.length) { el.revBody.innerHTML = `<div class="rep-ok">No spelling or grammar issues found across ${data.checked} text ${data.checked === 1 ? 'box' : 'boxes'}.</div>`; return; }
+      el.revBody.innerHTML = `<div class="rep-summary">${iss.length} issue${iss.length === 1 ? '' : 's'} found · ${data.checked} text boxes checked</div><ul class="rep-list">` +
+        iss.map((x) => `<li class="${x.severity === 'error' ? 'blocker' : 'warning'}"><b>p.${x.page}:</b> “${escHtml(x.original)}” → “${escHtml(x.fix)}”${x.note ? ` <span class="rep-dim">(${escHtml(x.note)})</span>` : ''}</li>`).join('') + '</ul>';
+    } catch (err) { el.revBody.innerHTML = `<div class="rep-note err">${escHtml(err.message)}</div>`; }
+  }
+  async function runThesaurus() {
+    if (el.main.hidden) return;
+    const one = sels.length === 1 && sels[0];
+    if (!one || one.kind !== 'text') { setStatus('Select a single text box first, then click Thesaurus.', 'err'); return; }
+    const word = String(one.text || '').trim();
+    if (!word) { setStatus('That text box is empty — nothing to look up.', 'err'); return; }
+    openReview('Thesaurus', `Synonyms for “${word.length > 40 ? word.slice(0, 40) + '…' : word}”. Click one to replace the selected text box.`);
+    el.revBody.innerHTML = '<div class="rep-note">Looking up…</div>';
+    try {
+      const r = await fetch('/api/thesaurus', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ word }) });
+      const data = await r.json();
+      if (!r.ok) { el.revBody.innerHTML = `<div class="rep-note err">${escHtml(data.error || 'Lookup failed.')}</div>`; return; }
+      const syns = data.synonyms || [];
+      if (!syns.length) { el.revBody.innerHTML = `<div class="rep-note">${escHtml(data.note || 'No synonyms found for that word.')}</div>`; return; }
+      const wrap = document.createElement('div'); wrap.className = 'syn-list';
+      syns.forEach((s) => { const b = document.createElement('button'); b.className = 'syn-chip'; b.textContent = s; b.addEventListener('click', () => replaceSelText(one, s)); wrap.appendChild(b); });
+      el.revBody.innerHTML = ''; el.revBody.appendChild(wrap);
+    } catch (err) { el.revBody.innerHTML = `<div class="rep-note err">${escHtml(err.message)}</div>`; }
+  }
+  function replaceSelText(ref, text) {
+    if (!curModel() || curModel().elements.indexOf(ref) < 0) { setStatus('That text box is no longer on the current page.', 'err'); return; }
+    pushUndo(); ref.text = text; ref._node.innerHTML = elHtml(ref); drawSel(); syncSelUI();
+    closeReview(); setStatus(`Replaced with “${text}”.`, 'ok');
+  }
+  function reviewWordCount() {
+    if (el.main.hidden) return;
+    let words = 0, chars = 0, boxes = 0;
+    const add = (t) => { const s = String(t || '').trim(); if (!s) return; boxes++; chars += s.length; words += (s.match(/\S+/g) || []).length; };
+    if (bookConfig) { add(bookConfig.title); add(bookConfig.subtitle); }
+    pageModels.forEach((pm) => pm.elements.forEach((e) => { if (e.kind === 'text') add(e.text); }));
+    openReview('Word count', 'Counts the reader-facing text you’ve added. Puzzle grids, clues, and answer keys are generated and not counted.');
+    el.revBody.innerHTML = `<div class="wc-grid">
+      <div class="wc-cell"><b>${words}</b><span>words</span></div>
+      <div class="wc-cell"><b>${chars}</b><span>characters</span></div>
+      <div class="wc-cell"><b>${boxes}</b><span>text boxes</span></div>
+      <div class="wc-cell"><b>${pageModels.length}</b><span>pages</span></div>
+    </div>`;
+  }
+
+  // --- Help tab: Help Center + Contact Support ---
+  const GH_REPO = 'https://github.com/Rakoren/Puzzleforge';
+  const HELP_ARTICLES = [
+    { cat: 'Getting Started', q: 'How do I open a book in the editor?',
+      a: 'Build a book in the <b>Book Builder</b> and click <b>Open in Editor</b>, or use <b>Open recipe</b> to load a saved <code>.json</code> book. Every page — title, matter, puzzles, and answer keys — appears in the page rail on the left.' },
+    { cat: 'Getting Started', q: 'What are the parts of the workspace?',
+      a: 'The <b>ribbon</b> (Home, Insert, Page Design, Review, View, Help) holds every tool. The <b>page rail</b> on the left lists your pages — click to open one, drag the ↑ ↓ ⧉ ✕ controls to reorder, duplicate, or delete. The <b>canvas</b> in the middle is your page; rulers frame it. Select an object to reveal the contextual <b>Format</b> tab.' },
+    { cat: 'Getting Started', q: 'How do I save my work?',
+      a: '<b>Save</b> writes a recipe file you can reopen later; it captures your page order and every text/shape/image you added. <b>Export</b> composites the whole book into a print-resolution PDF. Nothing is stored on a server — keep your recipe file safe.' },
+
+    { cat: 'Create & Format', q: 'How do I add text, shapes, and images?',
+      a: 'Use the <b>Insert</b> tab: <b>Text Box</b>, the shape buttons (rectangle, ellipse, triangle, star, line), <b>Image</b>, <b>WordArt</b> for styled titles, and <b>Symbol</b> for special characters. New objects drop onto the current page and can be dragged, resized (○ handle), and rotated.' },
+    { cat: 'Create & Format', q: 'How do I format text?',
+      a: 'Select a text box and use the <b>Home</b> tab: font, size, bold/italic/underline, color, alignment, and line spacing. <b>Format Painter</b> copies one object’s look onto another. <b>Find &amp; Replace</b> (Home) edits text across every page at once.' },
+    { cat: 'Create & Format', q: 'What is WordArt?',
+      a: '<b>Insert → WordArt</b> drops a preset styled title (outline + shadow effects). Because the editor and the PDF share one renderer, the effect prints exactly as you see it on screen.' },
+
+    { cat: 'Layout & Templates', q: 'How do I add a title page, copyright, or intro?',
+      a: 'Use <b>Insert → Page template</b>. Pick from built-in templates (Title Page, Copyright, Intro, and more) — each inserts a real, editable page. Build a page you like and use <b>Save as template…</b> to reuse it later.' },
+    { cat: 'Layout & Templates', q: 'How do I reorder, rename, or delete pages?',
+      a: 'From the <b>page rail</b> use ↑ ↓ to move, ⧉ to duplicate, ✕ to delete. The <b>Page Design</b> tab has the same controls plus <b>Rename</b>, which gives a page a friendly name in the rail.' },
+    { cat: 'Layout & Templates', q: 'How do color schemes and page frames work?',
+      a: '<b>Page Design → Schemes</b> applies a palette: it sets each page’s frame accent color, recolors your current selection, and becomes the default color for new shapes. Pair it with a border style so the frame prints.' },
+    { cat: 'Layout & Templates', q: 'How do I check my margins?',
+      a: 'Turn on <b>Page Design → Show safe-margin guide</b> for a keep-clear overlay, and <b>View → Boundaries</b> to outline the page edge. Neither prints — they’re on-screen guides only.' },
+
+    { cat: 'Print & Export', q: 'How do I export a print-ready PDF?',
+      a: 'Click <b>Export</b>. The PDF honors your book’s trim size and bleed, and composites every object at print resolution. What you see on the canvas is what prints.' },
+    { cat: 'Print & Export', q: 'How do I publish to KDP?',
+      a: 'Open <b>Publish</b>. It runs a <b>pre-flight check</b> (trim, page count, margins) and a <b>proofread</b>, then bundles everything KDP needs — <code>interior.pdf</code>, <code>cover.pdf</code>, and a <code>build-info.txt</code> sheet — into one <code>.zip</code>. You can export even with warnings for now.' },
+    { cat: 'Print & Export', q: 'How do I make a cover?',
+      a: 'From the Publish window click <b>Open Cover Builder</b>. Design your cover, click <b>Use for this book</b>, and return — the package picks it up and matches the spine width to your real page count automatically.' },
+
+    { cat: 'Troubleshooting', q: 'Spelling or Thesaurus says it needs an API key',
+      a: 'Those tools use Claude. Set the <code>ANTHROPIC_API_KEY</code> environment variable and restart the server. Word Count and everything else work without a key.' },
+    { cat: 'Troubleshooting', q: 'My object looks different in the exported PDF',
+      a: 'The editor and PDF use the same renderer, so differences usually mean a font fell back. Stick to the provided font families, and remember the safe-margin guide and boundaries are screen-only and never print.' },
+    { cat: 'Troubleshooting', q: 'Export produces a blank or failed PDF',
+      a: 'PDF export needs Chromium available to the server. If it can’t be found, the server logs a message with how to point it at a Chromium binary. Re-run once that’s set.' },
+
+    { cat: 'Team', q: 'How does the team workspace work?',
+      a: 'PuzzleForge includes a self-hosted <b>workspace server</b> — no accounts host, no monthly bill. Run the app on one machine and have teammates on the same network open <code>http://&lt;that-machine’s-IP&gt;:&lt;port&gt;</code> in their browser. Everyone then shares one <b>team roster</b>, a <b>Team library</b> of books, and <b>live comments</b>.' },
+    { cat: 'Team', q: 'How do I share a book with my team?',
+      a: 'Open the book, go to the <b>Mailings</b> tab, and click <b>☁ Share to team</b>. It appears under <b>My Books → Team library</b> for everyone on the workspace, who can open it. Re-sharing updates the same team copy.' },
+    { cat: 'Team', q: 'Where are team comments and the roster stored?',
+      a: 'On the machine running the server, in a local <code>data/</code> folder (plain files — easy to back up). Add a <code>PUZZLEFORGE_WORKSPACE_TOKEN</code> environment variable to require a shared token; leave it unset to trust your local network.' },
+
+    { cat: 'Shortcuts', q: 'Keyboard shortcuts',
+      a: '<b>Ctrl+Z / Ctrl+Y</b> undo / redo · <b>Ctrl+C / Ctrl+V</b> copy / paste · <b>Ctrl+D</b> duplicate · <b>Delete</b> remove selected · <b>Arrow keys</b> nudge 1px (<b>Shift</b> = 10px) · drag to move, ○ handle to resize.' },
+  ];
+  function openHelp(cat) {
+    if (!el.helpModal) return;
+    el.helpModal.hidden = false;
+    if (cat) el.helpSearch.value = '';
+    renderHelp(el.helpSearch.value.trim(), cat || null);
+    if (!cat) setTimeout(() => el.helpSearch.focus(), 30);
+  }
+  function closeHelp() { if (el.helpModal) el.helpModal.hidden = true; }
+  let helpCat = null;
+  function renderHelp(query, cat) {
+    if (cat !== undefined) helpCat = cat;
+    const q = (query || '').toLowerCase();
+    const cats = [...new Set(HELP_ARTICLES.map((a) => a.cat))];
+    // Category rail (search overrides the active category filter).
+    el.helpCats.innerHTML = '';
+    const mkCat = (name, label) => { const b = document.createElement('button'); b.className = 'pf-help-cat' + ((!q && helpCat === name) ? ' active' : ''); b.textContent = label; b.addEventListener('click', () => { el.helpSearch.value = ''; renderHelp('', name); }); return b; };
+    el.helpCats.appendChild(mkCat(null, 'All topics'));
+    cats.forEach((c) => el.helpCats.appendChild(mkCat(c, c)));
+    // Articles filtered by search, else by active category.
+    const list = HELP_ARTICLES.filter((a) => q ? (a.q + ' ' + a.a + ' ' + a.cat).toLowerCase().includes(q) : (!helpCat || a.cat === helpCat));
+    if (!list.length) { el.helpArticles.innerHTML = `<p class="pf-modal-sub">No articles match “${escHtml(query)}”. Try another word, or <b>Contact Support</b>.</p>`; return; }
+    let html = ''; let lastCat = null;
+    list.forEach((a) => {
+      if (a.cat !== lastCat) { html += `<h3 class="pf-help-group">${escHtml(a.cat)}</h3>`; lastCat = a.cat; }
+      html += `<details class="pf-help-art"${q ? ' open' : ''}><summary>${escHtml(a.q)}</summary><div class="pf-help-ans">${a.a}</div></details>`;
+    });
+    el.helpArticles.innerHTML = html;
+  }
+
+  function openSupport() {
+    if (!el.supportModal) return;
+    if (el.supBrowse) el.supBrowse.href = GH_REPO + '/issues';
+    el.supStatus.textContent = ''; el.supStatus.className = 'pf-pub-status';
+    el.supportModal.hidden = false;
+    setTimeout(() => el.supTitle.focus(), 30);
+  }
+  function closeSupport() { if (el.supportModal) el.supportModal.hidden = true; }
+  function supportContext() {
+    const trim = (bookConfig && bookConfig.trimSize) || (dims ? `${dims.widthIn}×${dims.heightIn}in` : 'unknown');
+    return ['', '', '---', `Book: ${bookTitle() || '(untitled)'} · trim ${trim} · ${pageModels.length} pages`,
+      `Browser: ${navigator.userAgent}`, `Page: ${location.href}`].join('\n');
+  }
+  function submitSupport() {
+    const title = el.supTitle.value.trim();
+    if (!title) { el.supStatus.textContent = 'Add a one-line summary first.'; el.supStatus.className = 'pf-pub-status err'; return; }
+    const type = el.supType.value;
+    const prefix = type === 'bug' ? '[Bug] ' : type === 'feature' ? '[Feature] ' : '[Question] ';
+    const label = type === 'bug' ? 'bug' : type === 'feature' ? 'enhancement' : 'question';
+    let body = el.supBody.value.trim() || '(no details provided)';
+    if (el.supIncludeCtx.checked) body += supportContext();
+    const url = `${GH_REPO}/issues/new?title=${encodeURIComponent(prefix + title)}&body=${encodeURIComponent(body)}&labels=${encodeURIComponent(label)}`;
+    window.open(url, '_blank', 'noopener');
+    el.supStatus.textContent = 'Opened a pre-filled issue on GitHub in a new tab — review and post it there.';
+    el.supStatus.className = 'pf-pub-status ok';
+  }
+
+  // --- Mailings tab: team roster, handoffs, personalized links, notes ---
+  // Everything is local-first (roster in this browser; invites/handoffs open a
+  // pre-filled email you send). This is the seed for real accounts + sync later.
+  const b64e = (s) => btoa(unescape(encodeURIComponent(s)));
+  const b64d = (s) => decodeURIComponent(escape(atob(s)));
+  let team = loadTeam();
+  let me = { name: 'Me', role: 'Owner' };            // who I am (may be set by an invite link)
+  let inviteGreeting = null;                          // shown after the book finishes opening
+  let teamState = { stage: 'Draft', assigneeId: null, notes: [] };
+  const ROLE_COLORS = { Writer: '#1c7ed6', Editor: '#e8590c', Illustrator: '#9c36b5', Reviewer: '#2b8a3e', Owner: '#495057', Contributor: '#868e96' };
+  function loadTeam() { try { return JSON.parse(localStorage.getItem('pf_team') || '[]'); } catch (_) { return []; } }
+  function saveTeam() { try { localStorage.setItem('pf_team', JSON.stringify(team)); } catch (_) { /* */ } }
+  function loadTeamState() {
+    // Prefer state saved with the recipe; fall back to the last active book's.
+    let st = (bookConfig && bookConfig.teamState) || null;
+    if (!st) { try { st = JSON.parse(localStorage.getItem('pf_teamstate') || 'null'); } catch (_) { st = null; } }
+    teamState = Object.assign({ stage: 'Draft', assigneeId: null, notes: [] }, st || {});
+    if (!Array.isArray(teamState.notes)) teamState.notes = [];
+    if (el.mailStage) el.mailStage.value = teamState.stage || 'Draft';
+  }
+  function saveTeamState() {
+    if (bookConfig) bookConfig.teamState = teamState;            // travels with Save (recipe)
+    try { localStorage.setItem('pf_teamstate', JSON.stringify(teamState)); } catch (_) { /* */ }
+  }
+  const memberById = (id) => team.find((m) => m.id === id) || null;
+  const selectedMember = () => memberById(el.mailRecipient && el.mailRecipient.value);
+  function personalizedLink(m) {
+    return `${location.origin}${location.pathname}?invite=${encodeURIComponent(b64e(JSON.stringify({ n: m.name, r: m.role })))}`;
+  }
+  function renderRecipients() {
+    if (!el.mailRecipient) return;
+    const keep = el.mailRecipient.value;
+    el.mailRecipient.innerHTML = '<option value="">— pick a team member —</option>' +
+      team.map((m) => `<option value="${m.id}">${escHtml(m.name)} · ${escHtml(m.role)}</option>`).join('');
+    if (keep && memberById(keep)) el.mailRecipient.value = keep;
+  }
+  function renderTeamList() {
+    if (!el.teamList) return;
+    if (!team.length) { el.teamList.innerHTML = '<p class="pf-modal-sub">No team members yet. Add someone above.</p>'; return; }
+    el.teamList.innerHTML = '';
+    team.forEach((m) => {
+      const row = document.createElement('div'); row.className = 'pf-team-row';
+      const badge = `<span class="pf-role" style="background:${ROLE_COLORS[m.role] || '#868e96'}">${escHtml(m.role)}</span>`;
+      const assigned = teamState.assigneeId === m.id ? ' <span class="pf-assigned">● assigned</span>' : '';
+      row.innerHTML = `<div class="pf-team-who">${badge} <b>${escHtml(m.name)}</b>${assigned}<br><span class="pf-dim">${escHtml(m.email || 'no email')}</span></div>`;
+      const acts = document.createElement('div'); acts.className = 'pf-team-acts';
+      const mk = (label, title, fn) => { const b = document.createElement('button'); b.className = 'ghost mini'; b.textContent = label; b.title = title; b.addEventListener('click', fn); return b; };
+      acts.appendChild(mk('Invite', 'Email an invite to join', () => inviteMember(m)));
+      acts.appendChild(mk('Email book', 'Email this book to them', () => emailBook(m)));
+      acts.appendChild(mk('Copy link', 'Copy their personalized link', () => copyLink(m)));
+      const del = mk('✕', 'Remove', () => removeMember(m.id)); del.classList.add('del');
+      acts.appendChild(del);
+      row.appendChild(acts); el.teamList.appendChild(row);
+    });
+  }
+  function openTeam(focusAdd) { if (!el.teamModal) return; renderTeamList(); if (wsEnabled) syncTeamFromServer(); el.teamModal.hidden = false; if (focusAdd) setTimeout(() => el.teamName.focus(), 30); }
+  function closeTeam() { if (el.teamModal) el.teamModal.hidden = true; }
+  // When a workspace is running, the roster is shared: read/write the server.
+  async function syncTeamFromServer() {
+    if (!wsEnabled || !window.PFWorkspace) return;
+    try { const members = await PFWorkspace.members(); team = members.map((m) => ({ id: m.id, name: m.name, email: m.email, role: m.role })); renderTeamList(); renderRecipients(); } catch (_) { /* */ }
+  }
+  async function addMember() {
+    const name = el.teamName.value.trim(); const email = el.teamEmail.value.trim(); const role = el.teamRole.value;
+    if (!name) { setStatus('Give the team member a name.', 'err'); el.teamName.focus(); return; }
+    if (wsEnabled && window.PFWorkspace) {
+      try { const m = await PFWorkspace.addMember({ name, email, role }); team.push({ id: m.id, name: m.name, email: m.email, role: m.role }); }
+      catch (_) { setStatus('Could not add to the shared roster — is the workspace running?', 'err'); return; }
+    } else {
+      team.push({ id: 't' + Date.now().toString(36), name, email, role });
+      saveTeam();
+    }
+    el.teamName.value = ''; el.teamEmail.value = '';
+    renderTeamList(); renderRecipients();
+    setStatus(`Added ${name} (${role}) to the team${wsEnabled ? ' — shared with everyone' : ''}.`, 'ok');
+  }
+  async function removeMember(id) {
+    if (wsEnabled && window.PFWorkspace) { try { await PFWorkspace.removeMember(id); } catch (_) { /* */ } }
+    team = team.filter((m) => m.id !== id);
+    if (teamState.assigneeId === id) { teamState.assigneeId = null; saveTeamState(); }
+    if (!wsEnabled) saveTeam();
+    renderTeamList(); renderRecipients();
+  }
+  async function copyLink(m) {
+    const url = personalizedLink(m);
+    try { await navigator.clipboard.writeText(url); setStatus(`Copied ${m.name}'s personalized link. Send it to them so their notes are signed as ${m.role}.`, 'ok'); }
+    catch (_) { window.prompt(`Copy ${m.name}'s personalized link:`, url); }
+  }
+  function mailto(to, subject, body) {
+    window.open(`mailto:${encodeURIComponent(to || '')}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`, '_blank');
+  }
+  function inviteMember(m) {
+    const subject = 'Join me on PuzzleForge';
+    const body = [`Hi ${m.name},`, '', `I'd like you to help make puzzle books with me on PuzzleForge as ${m.role}.`,
+      '', 'Open your personalized link to get started:', personalizedLink(m), '', `— ${me.name}`].join('\n');
+    mailto(m.email, subject, body);
+    setStatus(`Opened an invite email for ${m.name}.`, 'ok');
+  }
+  function emailBook(m) {
+    const title = bookTitle() || 'Untitled book';
+    const stage = teamState.stage || 'Draft';
+    const subject = `PuzzleForge — “${title}” (${stage})`;
+    const body = [`Hi ${m.name},`, '', `Handing off “${title}” to you as ${m.role}. Current stage: ${stage}.`,
+      `Pages: ${pageModels.length}.`, '', 'Please find the exported PDF / recipe attached (I\'ll add it in my email app).',
+      '', 'Your link:', personalizedLink(m), '', `— ${me.name}`].join('\n');
+    mailto(m.email, subject, body);
+    setStatus(`Opened a handoff email for ${m.name}. Remember to attach your exported file.`, 'ok');
+  }
+  function assignBook() {
+    const m = selectedMember();
+    if (!m) { setStatus('Pick a team member in the Recipient list first.', 'err'); return; }
+    teamState.assigneeId = m.id; saveTeamState(); renderTeamList();
+    setStatus(`“${bookTitle() || 'This book'}” assigned to ${m.name} (${m.role}) at the ${teamState.stage} stage.`, 'ok');
+  }
+  function shareAction(fn) { const m = selectedMember(); if (!m) { setStatus('Pick a team member in the Recipient list first.', 'err'); return; } fn(m); }
+  // Handoff notes
+  const usingWorkspaceNotes = () => wsEnabled && !!workspaceId;
+  function openNotes() {
+    if (!el.notesModal) return;
+    if (el.notesSub) el.notesSub.textContent = usingWorkspaceNotes()
+      ? 'Live team comments — everyone on your workspace sees these and updates appear in real time.'
+      : 'Notes travel with this book so the next person has context. Saved with your recipe on Save. Share to team to make them live.';
+    renderNotes(); el.notesModal.hidden = false; setTimeout(() => el.noteText.focus(), 30);
+  }
+  function closeNotes() { if (el.notesModal) el.notesModal.hidden = true; }
+  function renderNoteList(notes) {
+    if (!el.notesList) return;
+    if (!notes.length) { el.notesList.innerHTML = '<p class="pf-modal-sub">No notes yet. Post the first handoff note below.</p>'; return; }
+    el.notesList.innerHTML = notes.map((n) => {
+      const when = n.when || (n.createdAt ? new Date(n.createdAt).toLocaleString() : '');
+      const badge = `<span class="pf-role" style="background:${ROLE_COLORS[n.role] || '#868e96'}">${escHtml(n.role)}</span>`;
+      return `<div class="pf-note"><div class="pf-note-head">${badge} <b>${escHtml(n.author)}</b> <span class="pf-dim">${escHtml(when)}</span></div><div class="pf-note-body">${escHtml(n.text)}</div></div>`;
+    }).join('');
+  }
+  async function renderNotes() {
+    if (!el.notesList) return;
+    if (!usingWorkspaceNotes()) { renderNoteList(teamState.notes); return; }
+    try { renderNoteList(await PFWorkspace.comments(workspaceId)); }
+    catch (_) { el.notesList.innerHTML = '<p class="rep-note err">Could not load team comments — is the workspace server running?</p>'; }
+  }
+  async function addNote() {
+    const text = el.noteText.value.trim(); if (!text) return;
+    if (usingWorkspaceNotes()) {
+      try { await PFWorkspace.addComment(workspaceId, { author: me.name, role: me.role, text }); el.noteText.value = ''; renderNotes(); }
+      catch (_) { setStatus('Could not post the comment to the workspace.', 'err'); }
+      return;
+    }
+    teamState.notes.push({ author: me.name, role: me.role, when: new Date().toLocaleString(), text });
+    saveTeamState(); el.noteText.value = ''; renderNotes();
+  }
+  function parseInvite() {
+    try {
+      const inv = new URLSearchParams(location.search).get('invite'); if (!inv) return;
+      const d = JSON.parse(b64d(decodeURIComponent(inv)));
+      if (d && d.n) { me = { name: String(d.n).slice(0, 60), role: String(d.r || 'Contributor').slice(0, 30) };
+        inviteGreeting = `Welcome, ${me.name} — you're here as ${me.role}. Your handoff notes will be signed with your name.`;
+        setStatus(inviteGreeting, 'ok'); }
+    } catch (_) { /* ignore malformed invite */ }
+  }
+
+  // --- Team workspace (self-hosted LAN server) --------------------------
+  function setWsStatus() {
+    if (!el.wsStatus) return;
+    if (detached) el.wsStatus.textContent = '⚠ Removed from team — save to keep';
+    else if (!wsEnabled) el.wsStatus.textContent = 'Workspace off';
+    else if (workspaceId && !currentLibId) el.wsStatus.textContent = '☁ Team book (live)';
+    else if (workspaceId) el.wsStatus.textContent = '✓ Shared with team';
+    else el.wsStatus.textContent = 'Not shared yet';
+    if (el.saveMineBtn) el.saveMineBtn.style.display = (isTeamBook() || detached) ? '' : 'none';
+  }
+  async function initWorkspace() {
+    if (!window.PFWorkspace) return;
+    const st = await PFWorkspace.status();
+    wsEnabled = !!st.enabled;
+    setWsStatus();
+    if (wsEnabled) subscribeWorkspace();
+  }
+  function subscribeWorkspace() {
+    if (wsSub || !window.PFWorkspace) return;
+    try {
+      wsSub = PFWorkspace.subscribe((evt) => {
+        // Live-refresh shared comments when someone else posts on this book.
+        if (evt.type === 'comment' && evt.bookId === workspaceId && el.notesModal && !el.notesModal.hidden) renderNotes();
+        // Keep the shared roster fresh when a teammate adds/removes someone.
+        if (evt.type === 'member' && el.teamModal && !el.teamModal.hidden) syncTeamFromServer();
+        // The owner removed this team book from the library while we have it open:
+        // stop pushing edits (a PUT would resurrect it) and prompt to keep a copy.
+        if (evt.type === 'book' && evt.removed && evt.id === workspaceId && isTeamBook()) {
+          detached = true; setWsStatus();
+          setStatus('⚠ This book was removed from the team library by the owner. Click “Save to my library” to keep your copy — otherwise your edits won’t be saved.', 'err');
+        }
+      });
+    } catch (_) { /* */ }
+  }
+  async function shareToTeam() {
+    if (!wsEnabled) { setStatus('No team workspace is running. Start the PuzzleForge server on your LAN to share.', 'err'); return; }
+    if (!bookOpen) return;
+    const id = workspaceId || currentLibId || (window.PFLibrary && PFLibrary.newId()) || ('bk_' + Date.now().toString(36));
+    setStatus('Sharing to the team workspace…', 'busy');
+    try {
+      await PFWorkspace.shareBook(id, buildRecipe(), me.name);
+      workspaceId = id; setWsStatus();
+      setStatus('Shared with the team — everyone on the workspace can now open it from My Books → Team library.', 'ok');
+    } catch (err) {
+      if (err.needsToken) setStatus('This workspace needs a token. Add it in My Books, then try again.', 'err');
+      else setStatus('Could not reach the workspace server: ' + err.message, 'err');
+    }
+  }
+
+  async function runPreflight() {
+    el.pubRunChecks.disabled = true; setPubStatus(el.pubCheckStatus, 'Rendering & checking…', 'busy');
+    const body = bookBody();
+    try {
+      const [chkR, proR] = await Promise.allSettled([
+        fetch('/api/book/checklist', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then((r) => r.json()),
+        fetch('/api/book/proofread', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then(async (r) => ({ ok: r.ok, data: await r.json() })),
+      ]);
+      const chk = chkR.status === 'fulfilled' ? chkR.value : { error: 'Could not render the book for checks.' };
+      let proof = { issues: [] };
+      if (proR.status === 'fulfilled') proof = proR.value.ok ? proR.value.data : { issues: [], error: proR.value.data.error };
+      else proof = { issues: [], error: 'Proofread request failed.' };
+      lastProofIssues = proof.issues || [];
+      renderReport(chk, proof);
+      setPubStatus(el.pubCheckStatus, '');
+    } catch (err) { setPubStatus(el.pubCheckStatus, err.message, 'err'); }
+    finally { el.pubRunChecks.disabled = false; }
+  }
+  function renderReport(chk, proof) {
+    el.pubReport.hidden = false;
+    const parts = [];
+    if (chk.error) parts.push(`<div class="rep-note err">Checklist error: ${escHtml(chk.error)}</div>`);
+    else {
+      const s = chk.summary || { blockers: 0, warnings: 0, passes: 0 };
+      parts.push(`<div class="rep-summary"><b>${chk.pageCount || '?'}</b> pages · <span class="rep-b">🔴 ${s.blockers}</span> <span class="rep-w">🟡 ${s.warnings}</span> <span class="rep-p">🟢 ${s.passes}</span></div>`);
+      const fails = (chk.items || []).filter((i) => i.status !== 'pass');
+      if (fails.length) parts.push('<ul class="rep-list">' + fails.map((i) => `<li class="${i.severity}"><b>${i.severity === 'blocker' ? 'Blocker' : 'Warning'}:</b> ${escHtml(i.label)} — ${escHtml(i.message)}</li>`).join('') + '</ul>');
+      else parts.push('<div class="rep-ok">All structural &amp; print-spec checks passed.</div>');
+    }
+    parts.push('<div class="rep-subhead">✍️ Proofread</div>');
+    if (proof.error) parts.push(`<div class="rep-note">Unavailable: ${escHtml(proof.error)}</div>`);
+    else if (proof.note && !(proof.issues || []).length) parts.push(`<div class="rep-note">${escHtml(proof.note)}</div>`);
+    else {
+      const iss = proof.issues || [];
+      if (iss.length) parts.push('<ul class="rep-list">' + iss.map((x) => `<li class="${x.severity === 'error' ? 'blocker' : 'warning'}"><b>p.${x.page}:</b> “${escHtml(x.original)}” → “${escHtml(x.fix)}”${x.note ? ` <span class="rep-dim">(${escHtml(x.note)})</span>` : ''}</li>`).join('') + '</ul>');
+      else parts.push('<div class="rep-ok">No spelling or grammar issues found.</div>');
+    }
+    el.pubReport.innerHTML = parts.join('');
+  }
+  async function exportPackage() {
+    el.pubExport.disabled = true; setPubStatus(el.pubExportStatus, 'Building package…', 'busy');
+    try {
+      const body = { ...bookBody(), metadata: gatherMeta(), proofreadIssues: lastProofIssues };
+      const cover = savedCover();
+      if (cover) body.coverFull = cover; else body.cover = gatherCover();
+      const res = await fetch('/api/book/package', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      if (!res.ok) { const d = await res.json().catch(() => ({})); throw new Error(d.error || 'Export failed'); }
+      downloadBlob(await res.blob(), slug((bookConfig && bookConfig.title) || 'book') + '-kdp-package.zip');
+      setPubStatus(el.pubExportStatus, 'Package downloaded ✓', 'ok');
+    } catch (err) { setPubStatus(el.pubExportStatus, err.message, 'err'); }
+    finally { el.pubExport.disabled = false; }
+  }
+
+  // --- ribbon (MS Publisher–style tabbed toolbar) ---
+  function setupRibbon() {
+    const tabs = [...document.querySelectorAll('.rtab')];
+    const panels = [...document.querySelectorAll('.ribbon-panel')];
+    if (!tabs.length) return;
+    ribbonActivate = (name) => {
+      tabs.forEach((t) => t.classList.toggle('active', t.dataset.tab === name));
+      panels.forEach((p) => p.classList.toggle('active', p.dataset.panel === name));
+    };
+    tabs.forEach((t) => t.addEventListener('click', () => { if (t.dataset.tab !== 'format') ribbonPrevTab = t.dataset.tab; ribbonActivate(t.dataset.tab); }));
+  }
+  // Contextual tab (Publisher-style): the Format tab is hidden from the strip
+  // until an object is selected, then it appears and relabels itself for the
+  // object type — Picture Format (image), Table, Text Box, or Drawing Tools
+  // (shape). It auto-activates on selection and returns to the previous tab when
+  // the selection clears. The align/order/arrange tools live on this Format tab
+  // (Publisher has no standalone Arrange tab).
+  // A text box also carries the object-specific tab (Text Box); other kinds get
+  // their own single tab. Plain shapes use only Shape Format.
+  const CTX_LABELS = { text: 'Text Box' };
+  function updateContextTab() {
+    if (!ribbonActivate || !el.ctxTab) return;
+    const one = sels.length === 1 ? sels[0] : null;
+    const kind = one && one.kind;
+    const isTable = kind === 'table';
+    const isImg = kind === 'image';
+    const isQr = kind === 'qr';
+    // Primary object tab (Text Box) — not for shapes, tables, pictures, or QR.
+    const hasPrimary = !!(kind && CTX_LABELS[kind]);
+    // Shape Format (frame) tab — text boxes and shapes.
+    const hasShapeFmt = kind === 'text' || kind === 'shape';
+    if (hasPrimary) { el.ctxTab.textContent = CTX_LABELS[kind]; el.ctxTab.classList.add('avail'); }
+    else el.ctxTab.classList.remove('avail');
+    if (el.ctxTab2) el.ctxTab2.classList.toggle('avail', hasShapeFmt);
+    if (el.ctxTabTD) el.ctxTabTD.classList.toggle('avail', isTable);
+    if (el.ctxTabTL) el.ctxTabTL.classList.toggle('avail', isTable);
+    if (el.ctxTabPic) el.ctxTabPic.classList.toggle('avail', isImg);
+    if (el.ctxTabQr) el.ctxTabQr.classList.toggle('avail', isQr);
+    // If we're on a contextual tab that no longer applies, fall back gracefully.
+    const active = document.querySelector('.rtab.active');
+    const cur = active ? active.dataset.tab : 'home';
+    const ok = { format: hasPrimary, shapeformat: hasShapeFmt, tabledesign: isTable, tablelayout: isTable, pictureformat: isImg, qrformat: isQr };
+    if (cur in ok && !ok[cur]) {
+      ribbonActivate(isTable ? 'tabledesign' : isImg ? 'pictureformat' : isQr ? 'qrformat' : hasPrimary ? 'format' : hasShapeFmt ? 'shapeformat' : (ribbonPrevTab || 'home'));
+    }
+  }
+
+  // --- theme (editor skin) ---
+  function applyTheme(dark) {
+    document.body.classList.toggle('theme-dark', dark);
+    try { localStorage.setItem('pf_theme', dark ? 'dark' : 'light'); } catch (_) { /* */ }
+  }
+  function setupTheme() {
+    let saved = null; try { saved = localStorage.getItem('pf_theme'); } catch (_) { /* */ }
+    const dark = saved ? saved === 'dark' : true; // default to the dark Publisher skin
+    if (el.darkToggle) { el.darkToggle.checked = dark; el.darkToggle.addEventListener('change', () => applyTheme(el.darkToggle.checked)); }
+    applyTheme(dark);
+  }
+
+  function init() {
+    setupRibbon(); setupTheme(); buildObjectMenus();
+    injectCustomFontFaces(); refreshFontSelects();
+    if (el.fontUpload) el.fontUpload.addEventListener('change', () => onFontUpload(el.fontUpload));
+    document.querySelectorAll('#bgDrop .bg-type').forEach((b) => b.addEventListener('click', () => setBgType(b.dataset.bg)));
+    if (el.bgColor) el.bgColor.addEventListener('change', () => setBgProp('color', el.bgColor.value));
+    if (el.bgColor2) el.bgColor2.addEventListener('change', () => setBgProp('color2', el.bgColor2.value));
+    if (el.bgAngle) el.bgAngle.addEventListener('change', () => setBgProp('angle', Number(el.bgAngle.value) || 0));
+    el.addText.addEventListener('click', addText);
+    el.addImage.addEventListener('change', (e) => { const f = e.target.files[0]; if (f) addImageFile(f); e.target.value = ''; });
+    if (el.addPicPlaceholder) el.addPicPlaceholder.addEventListener('click', addPicturePlaceholder);
+    if (el.insHeader) el.insHeader.addEventListener('click', () => addMasterText('header'));
+    if (el.insFooter) el.insFooter.addEventListener('click', () => addMasterText('footer'));
+    if (el.addCalendarBtn) el.addCalendarBtn.addEventListener('click', addCalendar);
+    if (el.insLinkBtn) el.insLinkBtn.addEventListener('click', linkSel);
+    if (el.insBookmarkBtn) el.insBookmarkBtn.addEventListener('click', bookmarkSel);
+    document.querySelectorAll('.shape-btn').forEach((b) => b.addEventListener('click', () => addShape(b.dataset.shape)));
+    // Font: live update on input, commit an undo entry on change.
+    // Font controls live on BOTH the Home tab and the contextual Text Box
+    // Format tab, so wire every matching control by class (shared behaviour).
+    const each = (sel, fn) => document.querySelectorAll(sel).forEach(fn);
+    each('.js-font-size', (i) => { i.addEventListener('input', () => applyTextProp('fontSize', Number(i.value) || 24)); i.addEventListener('change', () => { if (selText()) pushUndo(); }); });
+    each('.js-font-color', (c) => { c.addEventListener('input', () => applyTextProp('color', c.value)); c.addEventListener('change', () => { if (selText()) pushUndo(); }); });
+    each('.js-font-family', (s) => s.addEventListener('change', () => applyTextPropU('fontFamily', s.value)));
+    each('.js-font-grow', (b) => b.addEventListener('click', () => fontStep(2)));
+    each('.js-font-shrink', (b) => b.addEventListener('click', () => fontStep(-2)));
+    each('.js-font-case', (b) => b.addEventListener('click', changeCase));
+    each('.js-font-clear', (b) => b.addEventListener('click', clearTextFmt));
+    each('.js-line-spacing', (s) => s.addEventListener('change', () => applyTextPropU('lineHeight', Number(s.value) || 1.25)));
+    each('.palign', (b) => b.addEventListener('click', () => applyTextPropU('align', b.dataset.align)));
+    const tstyle = (prop) => { const o = selText(); if (o) applyTextPropU(prop, !o[prop]); };
+    each('.js-bold', (b) => b.addEventListener('click', () => tstyle('bold')));
+    each('.js-italic', (b) => b.addEventListener('click', () => tstyle('italic')));
+    each('.js-underline', (b) => b.addEventListener('click', () => tstyle('underline')));
+    // Text Box tab: outline colour + WordArt gallery + effects
+    if (el.tbHyphenBtn) el.tbHyphenBtn.addEventListener('click', () => { const o = selText(); if (o) applyTextPropU('hyphens', !o.hyphens); });
+    if (el.tbLinkCreate) el.tbLinkCreate.addEventListener('click', startCreateLink);
+    if (el.tbLinkBreak) el.tbLinkBreak.addEventListener('click', breakLink);
+    if (el.tbLinkPrev) el.tbLinkPrev.addEventListener('click', () => flowNav(-1));
+    if (el.tbLinkNext) el.tbLinkNext.addEventListener('click', () => flowNav(1));
+    buildWordArtGallery(); buildFillOutlineMenus();
+    buildShapeStyleMenus(); buildShapeStyleGallery(); buildSfShapeGallery(); buildSfChangeMenu();
+    if (el.sfEditText) el.sfEditText.addEventListener('click', () => { const o = sfSel(); if (o && o.kind === 'text') editText(o); });
+    if (el.sfForward) el.sfForward.addEventListener('click', () => reorder('forward'));
+    if (el.sfBackward) el.sfBackward.addEventListener('click', () => reorder('backward'));
+    if (el.sfGroup) el.sfGroup.addEventListener('click', groupSel);
+    if (el.sfUngroup) el.sfUngroup.addEventListener('click', ungroupSel);
+    if (el.sfW) el.sfW.addEventListener('change', () => { const o = sfSel(); if (o) { pushUndo(); o.w = Math.max(8, Number(el.sfW.value) || num(o.w, 160)); sfRerender(o); syncSelUI(); } });
+    if (el.sfH) el.sfH.addEventListener('change', () => { const o = sfSel(); if (o && o.kind === 'shape') { pushUndo(); o.h = Math.max(4, Number(el.sfH.value) || num(o.h, 120)); sfRerender(o); syncSelUI(); } });
+    // Table Design / Table Layout tabs
+    buildTableFormatGallery(); buildTableMenus();
+    if (el.tlInsAbove) el.tlInsAbove.addEventListener('click', () => tblInsRow('above'));
+    if (el.tlInsBelow) el.tlInsBelow.addEventListener('click', () => tblInsRow('below'));
+    if (el.tlInsLeft) el.tlInsLeft.addEventListener('click', () => tblInsCol('left'));
+    if (el.tlInsRight) el.tlInsRight.addEventListener('click', () => tblInsCol('right'));
+    if (el.tlForward) el.tlForward.addEventListener('click', () => reorder('forward'));
+    if (el.tlBackward) el.tlBackward.addEventListener('click', () => reorder('backward'));
+    if (el.tlEditText) el.tlEditText.addEventListener('click', () => setStatus('Double-click a cell to edit its text.', ''));
+    if (el.tdBorderW) el.tdBorderW.addEventListener('change', () => tblSet('borderW', Math.max(0, Math.min(8, Number(el.tdBorderW.value) || 0))));
+    if (el.tdHeader) el.tdHeader.addEventListener('change', () => tblSet('header', el.tdHeader.checked));
+    document.querySelectorAll('.tbl-align').forEach((b) => b.addEventListener('click', () => tblSet('align', b.dataset.talign)));
+    if (el.tlMerge) el.tlMerge.addEventListener('click', mergeTableCells);
+    if (el.tlSplit) el.tlSplit.addEventListener('click', splitTableCells);
+    if (el.tlDiagonal) el.tlDiagonal.addEventListener('click', toggleTableDiagonal);
+    // Picture Format tab
+    buildPicMenus(); buildPicStyleGallery(); buildPicBorderMenu();
+    if (el.picChange) el.picChange.addEventListener('change', () => { const o = selImage(); const f = el.picChange.files && el.picChange.files[0]; if (o && f) { const r = new FileReader(); r.onload = () => { pushUndo(); o.src = r.result; o.placeholder = false; delete o.crop; captureNatSize(o); picRerender(o); }; r.readAsDataURL(f); } el.picChange.value = ''; });
+    if (el.picCropBtn) el.picCropBtn.addEventListener('click', startCrop);
+    if (el.picSwap) el.picSwap.addEventListener('click', swapPictures);
+    if (el.picCropReset) el.picCropReset.addEventListener('click', resetCrop);
+    if (el.picCropFill) el.picCropFill.addEventListener('click', cropToSquare);
+    if (el.picReset) el.picReset.addEventListener('click', picResetAdjust);
+    if (el.picForward) el.picForward.addEventListener('click', () => reorder('forward'));
+    if (el.picBackward) el.picBackward.addEventListener('click', () => reorder('backward'));
+    if (el.picFlipH) el.picFlipH.addEventListener('click', () => flip('h'));
+    if (el.picFlipV) el.picFlipV.addEventListener('click', () => flip('v'));
+    if (el.picW) el.picW.addEventListener('change', () => { const o = selImage(); if (o) { pushUndo(); o.width = Math.max(16, Number(el.picW.value) || num(o.width, 160)); picRerender(o); syncSelUI(); } });
+    if (el.picCaptionText) el.picCaptionText.addEventListener('input', () => { const o = selImage(); if (o) { o.caption = el.picCaptionText.value; if (!o.captionStyle || o.captionStyle === 'none') o.captionStyle = 'below'; picRerender(o); } });
+    // Home Clipboard / Objects / Arrange / Editing
+    el.cutBtn.addEventListener('click', cutSel); el.copyBtn.addEventListener('click', copySel); el.pasteBtn.addEventListener('click', paste);
+    el.fmtPainter.addEventListener('click', togglePainter);
+    el.hAddText.addEventListener('click', addText);
+    el.hAddImage.addEventListener('change', (e) => { const f = e.target.files[0]; if (f) addImageFile(f); e.target.value = ''; });
+    el.hForward.addEventListener('click', () => reorder('forward')); el.hBackward.addEventListener('click', () => reorder('backward'));
+    el.hGroup.addEventListener('click', groupSel); el.hUngroup.addEventListener('click', ungroupSel);
+    el.findReplaceBtn.addEventListener('click', openFindReplace); el.selectAllBtn.addEventListener('click', selectAll);
+    if (el.breakApartBtn) el.breakApartBtn.addEventListener('click', breakApartPuzzle);
+    el.frClose.addEventListener('click', closeFindReplace);
+    el.frModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeFindReplace(); });
+    el.frReplaceAll.addEventListener('click', doReplaceAll);
+    el.fillColor.addEventListener('input', () => { el.noFill.checked = false; applyShapeProp('fill', el.fillColor.value); });
+    el.strokeColor.addEventListener('input', () => applyShapeProp('stroke', el.strokeColor.value));
+    el.strokeW.addEventListener('input', () => applyShapeProp('strokeW', Math.max(0, Number(el.strokeW.value) || 0)));
+    el.noFill.addEventListener('change', () => applyShapeProp('fill', el.noFill.checked ? 'none' : el.fillColor.value));
+    // Tables
+    if (el.addTable) el.addTable.addEventListener('click', () => addTable(3, 3));
+    if (el.tblAddRow) el.tblAddRow.addEventListener('click', () => tableOp((t) => { t.rows++; }));
+    if (el.tblDelRow) el.tblDelRow.addEventListener('click', () => tableOp((t) => { if (t.rows > 1) { t.rows--; t.cells.pop(); } }));
+    if (el.tblAddCol) el.tblAddCol.addEventListener('click', () => tableOp((t) => { t.cols++; t.colW.push(90); }));
+    if (el.tblDelCol) el.tblDelCol.addEventListener('click', () => tableOp((t) => { if (t.cols > 1) { t.cols--; t.colW.pop(); t.cells.forEach((row) => row.pop()); } }));
+    if (el.tblBorder) el.tblBorder.addEventListener('input', () => { const t = selTable(); if (t) { t.borderColor = el.tblBorder.value; redrawTable(t); } });
+    if (el.tblHeaderFill) el.tblHeaderFill.addEventListener('input', () => { const t = selTable(); if (t) { t.headerFill = el.tblHeaderFill.value; redrawTable(t); } });
+    if (el.tblHeader) el.tblHeader.addEventListener('change', () => { const t = selTable(); if (t) { pushUndo(); t.header = el.tblHeader.checked; redrawTable(t); } });
+    // QR codes — Insert button + QR Code contextual tab
+    if (el.addQr) el.addQr.addEventListener('click', addQr);
+    buildQrStyleGallery();
+    if (el.qrUrl) el.qrUrl.addEventListener('change', () => { const q = selQr(); if (q) { pushUndo(); q.url = el.qrUrl.value.trim(); reencodeQr(q); } });
+    if (el.qrFg) el.qrFg.addEventListener('input', () => { const q = selQr(); if (q) { q.fg = el.qrFg.value; qrRender(q); } });
+    if (el.qrFg) el.qrFg.addEventListener('change', () => { if (selQr()) pushUndo(); });
+    if (el.qrBg) el.qrBg.addEventListener('input', () => { const q = selQr(); if (q) { q.bg = el.qrBg.value; qrRender(q); } });
+    if (el.qrBg) el.qrBg.addEventListener('change', () => { if (selQr()) pushUndo(); });
+    if (el.qrTransparent) el.qrTransparent.addEventListener('change', () => { const q = selQr(); if (q) { pushUndo(); q.bg = el.qrTransparent.checked ? 'none' : (/^#/.test(el.qrBg.value) ? el.qrBg.value : '#ffffff'); qrRender(q); syncQrUI(q); } });
+    if (el.qrTest) el.qrTest.addEventListener('click', () => { const q = selQr(); if (q && q.url) window.open(q.url, '_blank', 'noopener'); else setStatus('This QR code has no link yet.', ''); });
+    if (el.qrW) el.qrW.addEventListener('change', () => { const q = selQr(); if (q) { pushUndo(); q.w = Math.max(24, Number(el.qrW.value) || num(q.w, 140)); qrRender(q); syncSelUI(); } });
+    if (el.qrForward) el.qrForward.addEventListener('click', () => reorder('forward'));
+    if (el.qrBackward) el.qrBackward.addEventListener('click', () => reorder('backward'));
+    if (el.qrDup) el.qrDup.addEventListener('click', duplicate);
+    if (el.qrReset) el.qrReset.addEventListener('click', resetSize);
+    if (el.qrHide) el.qrHide.addEventListener('click', hideComp);
+    el.groupBtn.addEventListener('click', groupSel); el.ungroupBtn.addEventListener('click', ungroupSel);
+    el.borderAll.addEventListener('click', () => { pageModels.forEach((pm) => { pm._border = el.border.value; }); renderPage(); setStatus(el.border.value ? 'Border applied to all pages.' : 'Border override cleared on all pages.', 'ok'); });
+    el.mX.addEventListener('change', () => setMeasure('x', Number(el.mX.value) || 0));
+    el.mY.addEventListener('change', () => setMeasure('y', Number(el.mY.value) || 0));
+    el.mW.addEventListener('change', () => setElSize('w', Number(el.mW.value) || 0));
+    el.mH.addEventListener('change', () => setElSize('h', Number(el.mH.value) || 0));
+    el.mScale.addEventListener('change', () => setMeasure('scale', Math.max(0.15, (Number(el.mScale.value) || 100) / 100)));
+    el.mRot.addEventListener('change', () => setMeasure('rot', Number(el.mRot.value) || 0));
+    document.querySelectorAll('.align-grid .iconbtn').forEach((b) => b.addEventListener('click', () => alignSel(b.dataset.align)));
+    el.lockObj.addEventListener('click', toggleLock);
+    el.dupObj.addEventListener('click', duplicate); el.resetPos.addEventListener('click', resetSize); el.hideObj.addEventListener('click', hideComp); el.deleteObj.addEventListener('click', deleteSel);
+    el.border.addEventListener('change', setBorder);
+    el.gridToggle.addEventListener('change', () => { if (gridEl) gridEl.style.display = el.gridToggle.checked ? '' : 'none'; });
+    el.reroll.addEventListener('click', reroll); el.resetLayout.addEventListener('click', resetLayout);
+    if (el.addBlank) el.addBlank.addEventListener('click', insertBlankAfterCurrent);
+    if (el.addBlankSide) el.addBlankSide.addEventListener('click', insertBlankAfterCurrent);
+    initDropdowns();
+    if (el.insertTpl) el.insertTpl.addEventListener('click', openTplPicker);
+    if (el.insertTplSide) el.insertTplSide.addEventListener('click', openTplPicker);
+    if (el.savePageTpl) el.savePageTpl.addEventListener('click', savePageAsTemplate);
+    if (el.changeTplBtn) el.changeTplBtn.addEventListener('click', openChangeTpl);
+    if (el.changeTplModal) el.changeTplModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeChangeTpl(); });
+    if (el.dupPage) el.dupPage.addEventListener('click', () => { if (cur >= 0) duplicatePage(cur); });
+    if (el.aiArtBtn) el.aiArtBtn.addEventListener('click', openAiArt);
+    if (el.insertDate) el.insertDate.addEventListener('click', insertDate);
+    // Page Design tab
+    if (el.renamePage) el.renamePage.addEventListener('click', renamePagePrompt);
+    if (el.delPage) el.delPage.addEventListener('click', () => { if (cur >= 0) deletePage(cur); });
+    if (el.movePageUp) el.movePageUp.addEventListener('click', () => { if (cur >= 0) movePage(cur, -1); });
+    if (el.movePageDown) el.movePageDown.addEventListener('click', () => { if (cur >= 0) movePage(cur, 1); });
+    if (el.marginGuide) el.marginGuide.addEventListener('change', applyMarginGuide);
+    if (el.alignGuidesChk) el.alignGuidesChk.addEventListener('change', () => { alignGuides = el.alignGuidesChk.checked; });
+    if (el.alignObjectsChk) el.alignObjectsChk.addEventListener('change', () => { alignObjects = el.alignObjectsChk.checked; });
+    // Drag off a ruler to place a guide: down from the top ruler → horizontal;
+    // right from the left ruler → vertical.
+    el.rulerTop.addEventListener('pointerdown', (ev) => startRulerCreate(ev, 'h'));
+    el.rulerLeft.addEventListener('pointerdown', (ev) => startRulerCreate(ev, 'v'));
+    // Master pages
+    if (el.editMasterBtn) el.editMasterBtn.addEventListener('click', toggleMaster);
+    if (el.exitMasterBtn) el.exitMasterBtn.addEventListener('click', exitMaster);
+    if (el.insertPageNo) el.insertPageNo.addEventListener('click', insertPageNumber);
+    if (el.masterEnabled) el.masterEnabled.addEventListener('change', () => { master.enabled = el.masterEnabled.checked; if (!masterMode) renderPage(); setStatus(master.enabled ? 'Master overlay shown on pages.' : 'Master overlay hidden.', 'ok'); });
+    if (el.masterApplyTo) el.masterApplyTo.addEventListener('change', () => { master.applyTo = el.masterApplyTo.value; if (!masterMode) renderPage(); });
+    if (el.masterSkip) el.masterSkip.addEventListener('change', () => { master.skipFirst = Math.max(0, Number(el.masterSkip.value) || 0); if (!masterMode) renderPage(); });
+    if (el.masterStart) el.masterStart.addEventListener('change', () => { master.startAt = Number(el.masterStart.value) || 1; if (!masterMode) renderPage(); });
+    renderSchemes();
+    // Review tab
+    if (el.revSpelling) el.revSpelling.addEventListener('click', runSpelling);
+    if (el.revThesaurus) el.revThesaurus.addEventListener('click', runThesaurus);
+    if (el.revWordCount) el.revWordCount.addEventListener('click', reviewWordCount);
+    if (el.revClose) el.revClose.addEventListener('click', closeReview);
+    if (el.revModal) el.revModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeReview(); });
+    if (el.revLanguage) el.revLanguage.addEventListener('change', () => {
+      if (bookConfig) bookConfig.language = el.revLanguage.value;
+      setStatus(`Book language set to ${el.revLanguage.options[el.revLanguage.selectedIndex].text} (used in the KDP package metadata).`, 'ok');
+    });
+    // Help tab
+    if (el.helpBtn) el.helpBtn.addEventListener('click', () => openHelp());
+    if (el.shortcutsBtn) el.shortcutsBtn.addEventListener('click', () => openHelp('Shortcuts'));
+    if (el.helpClose) el.helpClose.addEventListener('click', closeHelp);
+    if (el.helpModal) el.helpModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeHelp(); });
+    if (el.helpSearch) el.helpSearch.addEventListener('input', () => renderHelp(el.helpSearch.value.trim()));
+    if (el.helpToSupport) el.helpToSupport.addEventListener('click', () => { closeHelp(); openSupport(); });
+    if (el.supportBtn) el.supportBtn.addEventListener('click', openSupport);
+    if (el.supportClose) el.supportClose.addEventListener('click', closeSupport);
+    if (el.supportModal) el.supportModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeSupport(); });
+    if (el.supSubmit) el.supSubmit.addEventListener('click', submitSupport);
+    // Mailings tab
+    if (el.teamBtn) el.teamBtn.addEventListener('click', () => openTeam(false));
+    if (el.inviteBtn) el.inviteBtn.addEventListener('click', () => openTeam(true));
+    if (el.teamClose) el.teamClose.addEventListener('click', closeTeam);
+    if (el.teamModal) el.teamModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeTeam(); });
+    if (el.teamAdd) el.teamAdd.addEventListener('click', addMember);
+    if (el.teamName) el.teamName.addEventListener('keydown', (e) => { if (e.key === 'Enter') addMember(); });
+    if (el.emailBookBtn) el.emailBookBtn.addEventListener('click', () => shareAction(emailBook));
+    if (el.linkBtn) el.linkBtn.addEventListener('click', () => shareAction(copyLink));
+    if (el.assignBtn) el.assignBtn.addEventListener('click', assignBook);
+    if (el.mailStage) el.mailStage.addEventListener('change', () => { teamState.stage = el.mailStage.value; saveTeamState(); setStatus(`Workflow stage set to ${teamState.stage}.`, 'ok'); });
+    if (el.notesBtn) el.notesBtn.addEventListener('click', openNotes);
+    if (el.notesClose) el.notesClose.addEventListener('click', closeNotes);
+    if (el.notesModal) el.notesModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeNotes(); });
+    if (el.noteAdd) el.noteAdd.addEventListener('click', addNote);
+    if (el.shareTeamBtn) el.shareTeamBtn.addEventListener('click', shareToTeam);
+    if (el.saveMineBtn) el.saveMineBtn.addEventListener('click', saveToMyLibrary);
+    renderRecipients();
+    parseInvite();
+    initWorkspace();
+    populateInsertMenus();
+    if (el.wordArt) el.wordArt.addEventListener('change', () => { const i = Number(el.wordArt.value); if (WORDART[i]) addWordArt(WORDART[i]); el.wordArt.value = ''; });
+    if (el.symbolPick) el.symbolPick.addEventListener('change', () => { addSymbol(el.symbolPick.value); el.symbolPick.value = ''; });
+    if (el.tplClose) el.tplClose.addEventListener('click', closeTplPicker);
+    if (el.changeTplClose) el.changeTplClose.addEventListener('click', closeChangeTpl);
+    if (el.tplModal) el.tplModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closeTplPicker(); });
+    if (el.puzClose) el.puzClose.addEventListener('click', closePuzzleInsert);
+    if (el.puzModal) el.puzModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closePuzzleInsert(); });
+    if (el.puzInsert) el.puzInsert.addEventListener('click', insertPuzzlePages);
+    if (el.puzAudience) el.puzAudience.addEventListener('change', fillPuzDiffOptions);
+    if (el.puzType) el.puzType.addEventListener('change', syncPuzTypeUI);
+    if (el.publishBtn) el.publishBtn.addEventListener('click', openPublish);
+    if (el.pubClose) el.pubClose.addEventListener('click', closePublish);
+    if (el.pubModal) el.pubModal.addEventListener('click', (e) => { if (e.target.hasAttribute('data-close')) closePublish(); });
+    if (el.pubRunChecks) el.pubRunChecks.addEventListener('click', runPreflight);
+    if (el.pubExport) el.pubExport.addEventListener('click', exportPackage);
+    if (el.pubOpenCover) el.pubOpenCover.addEventListener('click', openCoverBuilder);
+    if (el.pubClearCover) el.pubClearCover.addEventListener('click', clearCover);
+    // Re-check for a Cover Builder hand-off when returning to this tab.
+    window.addEventListener('focus', () => { if (el.pubModal && !el.pubModal.hidden) refreshCoverState(); });
+    el.undo.addEventListener('click', undo); el.redo.addEventListener('click', redo);
+    el.zoomIn.addEventListener('click', () => setZoom(zoom * 1.2)); el.zoomOut.addEventListener('click', () => setZoom(zoom / 1.2)); el.zoomFit.addEventListener('click', () => setZoom(fitScale()));
+    if (el.zoom100) el.zoom100.addEventListener('click', () => setZoom(1));
+    if (el.zoomWhole) el.zoomWhole.addEventListener('click', () => setZoom(fitScale()));
+    if (el.zoomWidth) el.zoomWidth.addEventListener('click', () => setZoom(fitWidth()));
+    if (el.rulerToggle) el.rulerToggle.addEventListener('change', toggleRulers);
+    if (el.navToggle) el.navToggle.addEventListener('change', toggleNav);
+    if (el.boundToggle) el.boundToggle.addEventListener('change', toggleBounds);
+    if (el.spreadToggle) el.spreadToggle.addEventListener('change', toggleSpread);
+    if (el.viewSingle) el.viewSingle.addEventListener('click', () => setSpreadMode(false));
+    if (el.viewSpread) el.viewSpread.addEventListener('click', () => setSpreadMode(true));
+    if (el.viewNormal) el.viewNormal.addEventListener('click', exitMaster);
+    if (el.viewMaster) el.viewMaster.addEventListener('click', enterMaster);
+    el.save.addEventListener('click', save); el.exportPdf.addEventListener('click', exportPdf); el.loadRecipe.addEventListener('change', onLoadRecipe);
+    el.stageScroll.addEventListener('scroll', syncRulers);
+    // Marquee (rubber-band) select. Capture phase, so we decide BEFORE a piece
+    // grabs the press: free elements keep their own click+drag; pressing on the
+    // stage background or a puzzle/matter piece starts a rubber-band. A real
+    // drag selects the enclosed objects; a plain click just selects the object
+    // under the pointer (or clears). An already-selected piece still drags.
+    el.stageInner.addEventListener('pointerdown', (e) => {
+      if (e.button !== 0 || linkPickMode || swapPickMode) return;
+      const t = e.target;
+      if (!t.closest) return;
+      // Interactive chrome handles its own press: resize/rotate handles &
+      // selection boxes (sel layer) and draggable ruler guides.
+      if (t.closest('.pf-sel-layer') || t.closest('.pf-user-guide') || t.closest('.pf-guide')) return;
+      const additive = e.shiftKey || e.ctrlKey || e.metaKey;
+      const nodeEl = t.closest('.pf-node');
+      if (nodeEl) {
+        // Plain press on a free object drags it (its own handler). A modifier
+        // press instead starts an additive rubber-band — so you can lasso more
+        // objects even when the press lands on top of one — and a modifier click
+        // with no drag adds that object to the selection.
+        if (!additive) return;
+        e.stopPropagation();
+        startMarquee(e, true, nodeEl._ref);
+        return;
+      }
+      const pieceNode = t.closest('.pf-piece');
+      const pieceRef = pieceNode ? pieceNode._ref : null;
+      if (pieceRef && isSel(pieceRef) && !additive) return; // already selected → let it drag
+      e.stopPropagation(); // suppress the piece's own select/drag
+      startMarquee(e, additive, pieceRef);
+    }, true);
+    el.stageInner.addEventListener('contextmenu', (e) => {
+      const t = e.target.closest ? e.target.closest('.pf-piece, .pf-node') : null;
+      const ref = t && t._ref;
+      if (ref && !isSel(ref)) setSel(expandGroups([ref]));
+      else if (!ref) setSel([]);
+      showCtx(e);
+    });
+    document.addEventListener('pointerdown', (e) => { if (ctxEl && !ctxEl.contains(e.target)) hideCtx(); }, true);
+    el.stageScroll.addEventListener('scroll', hideCtx);
+    window.addEventListener('resize', () => applyZoom());
+    window.addEventListener('keydown', onKey);
+    let handoff = null;
+    try { const raw = localStorage.getItem('pf_editor'); if (raw) { handoff = JSON.parse(raw); localStorage.removeItem('pf_editor'); } } catch (_) { /* */ }
+    if (handoff && handoff.recipe) { currentLibId = handoff.libId || null; workspaceId = handoff.workspaceId || null; loadRecipeObject(handoff.recipe); }
+    else if (handoff && (handoff.config || handoff.bookId)) { autoBreak = true; bookConfig = handoff.config || null; openBook(handoff.bookId ? { bookId: handoff.bookId, config: handoff.config } : { config: handoff.config }); }
+    else { el.empty.hidden = false; setStatus('Open a book from the Book Builder, or load a recipe.', ''); }
+    // Best-effort flush of pending changes when leaving the page.
+    window.addEventListener('beforeunload', () => { try { autosaveTick(); } catch (_) { /* */ } });
+  }
+  // Open a full recipe object (from the library handoff or an imported file).
+  function loadRecipeObject(raw) {
+    const v2 = raw && raw.recipeVersion === 2 ? raw : { book: raw, seed: raw && raw.seed };
+    bookConfig = { ...(v2.book || {}) };
+    if (v2.seed != null) bookConfig.seed = v2.seed;
+    if (Array.isArray(v2.pagePlan) && v2.pagePlan.length) pendingPlan = v2.pagePlan;
+    else if (Array.isArray(v2.pageState) && v2.pageState.length) bookConfig.pageState = v2.pageState;
+    return openBook({ config: bookConfig });
+  }
+  function onKey(e) {
+    if (linkPickMode && e.key === 'Escape') { e.preventDefault(); cancelLink(); setStatus('Link cancelled.', ''); return; }
+    if (swapPickMode && e.key === 'Escape') { e.preventDefault(); cancelSwap(); setStatus('Swap cancelled.', ''); return; }
+    if (cropTarget) { if (e.key === 'Enter') { e.preventDefault(); endCrop(true); } else if (e.key === 'Escape') { e.preventDefault(); endCrop(false); } return; }
+    if (el.tplModal && !el.tplModal.hidden) { if (e.key === 'Escape') closeTplPicker(); return; }
+    if (el.changeTplModal && !el.changeTplModal.hidden) { if (e.key === 'Escape') closeChangeTpl(); return; }
+    if (el.puzModal && !el.puzModal.hidden) { if (e.key === 'Escape') closePuzzleInsert(); return; }
+    if (el.pubModal && !el.pubModal.hidden) { if (e.key === 'Escape') closePublish(); return; }
+    if (el.frModal && !el.frModal.hidden) { if (e.key === 'Escape') closeFindReplace(); return; }
+    if (el.main.hidden) return; const ae = document.activeElement, tag = (ae && ae.tagName) || '';
+    if (/INPUT|SELECT|TEXTAREA/.test(tag) || (ae && ae.isContentEditable)) return;
+    const ctrl = e.ctrlKey || e.metaKey;
+    if (e.key === 'Escape') { hideCtx(); setSel([]); return; }
+    if (ctrl && e.key.toLowerCase() === 'z') { e.preventDefault(); e.shiftKey ? redo() : undo(); return; }
+    if (ctrl && e.key.toLowerCase() === 'y') { e.preventDefault(); redo(); return; }
+    if (ctrl && e.key.toLowerCase() === 'a') { e.preventDefault(); selectAll(); return; }
+    if (ctrl && e.key.toLowerCase() === 'c') { e.preventDefault(); copySel(); return; }
+    if (ctrl && e.key.toLowerCase() === 'x') { e.preventDefault(); cutSel(); return; }
+    if (ctrl && e.key.toLowerCase() === 'v') { e.preventDefault(); paste(); return; }
+    if (ctrl && e.key.toLowerCase() === 'd') { e.preventDefault(); duplicate(); return; }
+    if (ctrl && e.key.toLowerCase() === 'g') { e.preventDefault(); e.shiftKey ? ungroupSel() : groupSel(); return; }
+    if (!sels.length) return; const step = e.shiftKey ? 10 : 1;
+    if (e.key === 'ArrowLeft') { nudge(-step, 0); e.preventDefault(); } else if (e.key === 'ArrowRight') { nudge(step, 0); e.preventDefault(); }
+    else if (e.key === 'ArrowUp') { nudge(0, -step); e.preventDefault(); } else if (e.key === 'ArrowDown') { nudge(0, step); e.preventDefault(); }
+    else if (e.key === 'Delete' || e.key === 'Backspace') { deleteSel(); e.preventDefault(); }
+  }
+  function onLoadRecipe(ev) {
+    const file = ev.target.files && ev.target.files[0]; if (!file) return; const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const raw = JSON.parse(reader.result);
+        currentLibId = null;           // an imported file becomes a new library book
+        loadRecipeObject(raw);
+      } catch (_) { setStatus('That file is not a valid book recipe.', 'err'); }
+      ev.target.value = '';
+    };
+    reader.readAsText(file);
+  }
+  init();
+})();

--- a/publisher/public/favicon.svg
+++ b/publisher/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="7" fill="#3b5bdb"/>
+  <g fill="#ffffff">
+    <rect x="7" y="7" width="5" height="5" rx="1"/>
+    <rect x="13.5" y="7" width="5" height="5" rx="1"/>
+    <rect x="20" y="7" width="5" height="5" rx="1"/>
+    <rect x="7" y="13.5" width="5" height="5" rx="1"/>
+    <rect x="13.5" y="13.5" width="5" height="5" rx="1" fill="#ffd43b"/>
+    <rect x="20" y="13.5" width="5" height="5" rx="1"/>
+    <rect x="7" y="20" width="5" height="5" rx="1"/>
+    <rect x="13.5" y="20" width="5" height="5" rx="1"/>
+    <rect x="20" y="20" width="5" height="5" rx="1"/>
+  </g>
+</svg>

--- a/publisher/public/identity.js
+++ b/publisher/public/identity.js
@@ -1,0 +1,236 @@
+/**
+ * PuzzleForge identity (shared across every page).
+ *
+ * Talks to the workspace identity API (/api/workspace) to sign a person in by
+ * picking their profile (+ optional PIN), remembers the session token in this
+ * browser, and self-mounts a "Signed in as …" chip in the top-right with a menu
+ * (Profile settings, Switch user, Sign out). Also handles ?invite=<token> links
+ * so a new teammate can join. No build step, no dependencies.
+ *
+ * window.PFIdentity: { me(), onReady(cb), refresh(), signOut(), openSignIn(),
+ *                      token(), authHeaders() }
+ */
+(function () {
+  const WS = '/api/workspace';
+  const KEY = 'pf_session';
+  let me = null;            // current profile (or null)
+  let ready = false;
+  const readyCbs = [];
+
+  const token = () => { try { return localStorage.getItem(KEY) || ''; } catch (_) { return ''; } };
+  const setToken = (t) => { try { t ? localStorage.setItem(KEY, t) : localStorage.removeItem(KEY); } catch (_) {} };
+  const wsToken = () => { try { return localStorage.getItem('pf_ws_token') || ''; } catch (_) { return ''; } };
+
+  function authHeaders(json) {
+    const h = {};
+    if (json) h['Content-Type'] = 'application/json';
+    const t = token(); if (t) h['x-pf-session'] = t;
+    const w = wsToken(); if (w) h['x-pf-workspace'] = w;
+    return h;
+  }
+  async function api(method, path, body) {
+    const r = await fetch(WS + path, { method, headers: authHeaders(!!body), body: body ? JSON.stringify(body) : undefined });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(data.error || (r.status + ' error'));
+    return data;
+  }
+
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  const initials = (n) => String(n || '?').trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('').toUpperCase();
+
+  // --- chip -------------------------------------------------------------
+  let chip;
+  function mountChip() {
+    chip = document.createElement('div');
+    chip.id = 'pf-identity';
+    // Prefer sitting inside the page's nav (grouped with the links on the right);
+    // fall back to a floating top-right chip on pages without a topbar.
+    const nav = document.querySelector('.topbar .nav');
+    if (nav) nav.appendChild(chip);
+    else { chip.classList.add('floating'); document.body.appendChild(chip); }
+    renderChip();
+    document.addEventListener('click', (e) => { if (chip && !chip.contains(e.target)) chip.classList.remove('open'); });
+  }
+  function renderChip() {
+    if (!chip) return;
+    if (!me) {
+      chip.className = 'pf-id-chip signed-out';
+      chip.innerHTML = `<button class="pf-id-btn" type="button">Sign in</button>`;
+      chip.querySelector('.pf-id-btn').addEventListener('click', openSignIn);
+      return;
+    }
+    chip.className = 'pf-id-chip';
+    const avatarBg = me.color || '#3b6fd4';
+    chip.innerHTML = `
+      <button class="pf-id-btn" type="button" aria-haspopup="true">
+        <span class="pf-id-av" style="background:${esc(avatarBg)}">${esc(initials(me.name))}</span>
+        <span class="pf-id-name">${esc(me.name)}</span>
+        <span class="pf-id-role">${esc(me.role)}</span>
+        <span class="pf-id-caret">▾</span>
+      </button>
+      <div class="pf-id-menu" role="menu">
+        <a href="profile.html" role="menuitem">Profile settings</a>
+        <button type="button" role="menuitem" data-act="switch">Switch user</button>
+        <button type="button" role="menuitem" data-act="signout">Sign out</button>
+      </div>`;
+    chip.querySelector('.pf-id-btn').addEventListener('click', (e) => { e.stopPropagation(); chip.classList.toggle('open'); });
+    chip.querySelector('[data-act="switch"]').addEventListener('click', () => { chip.classList.remove('open'); openSignIn(); });
+    chip.querySelector('[data-act="signout"]').addEventListener('click', signOut);
+  }
+
+  // --- modal ------------------------------------------------------------
+  let modal;
+  function closeModal() { if (modal) { modal.remove(); modal = null; } }
+  function openModal(html) {
+    closeModal();
+    modal = document.createElement('div');
+    modal.className = 'pf-id-overlay';
+    modal.innerHTML = `<div class="pf-id-modal">${html}</div>`;
+    modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+    document.body.appendChild(modal);
+    return modal;
+  }
+  const field = (label, id, attrs = '') => `<label class="pf-id-field"><span>${esc(label)}</span><input id="${id}" ${attrs}></label>`;
+
+  async function openSignIn() {
+    let profiles = [];
+    try { profiles = await api('GET', '/profiles'); } catch (_) { /* workspace off? */ }
+    if (!profiles.length) return openCreateFirst();
+
+    const rows = profiles.map((p) => `
+      <button class="pf-id-pick" type="button" data-id="${p.id}" data-pin="${p.hasPin ? 1 : 0}">
+        <span class="pf-id-av" style="background:${esc(p.color || '#3b6fd4')}">${esc(initials(p.name))}</span>
+        <span class="pf-id-pick-main"><b>${esc(p.name)}</b><small>${esc(p.role)}${p.hasPin ? ' · PIN' : ''}</small></span>
+      </button>`).join('');
+    const m = openModal(`
+      <h2>Who's using PuzzleForge?</h2>
+      <div class="pf-id-picklist">${rows}</div>
+      <div class="pf-id-pinrow hidden"><label class="pf-id-field"><span>PIN</span><input id="pf-id-pin" type="password" inputmode="numeric" autocomplete="off"></label><button id="pf-id-pinok" class="primary" type="button">Sign in</button></div>
+      <p class="pf-id-err" id="pf-id-err"></p>
+      <div class="pf-id-modal-foot"><button id="pf-id-add" class="ghost" type="button">+ Add someone</button><button id="pf-id-cancel" class="ghost" type="button">Cancel</button></div>`);
+    let pending = null;
+    const pinRow = m.querySelector('.pf-id-pinrow');
+    const doPick = async (id, pin) => {
+      try { const r = await api('POST', '/session', { profileId: id, pin }); finishSignIn(r); }
+      catch (err) { m.querySelector('#pf-id-err').textContent = err.message; }
+    };
+    m.querySelectorAll('.pf-id-pick').forEach((b) => b.addEventListener('click', () => {
+      const id = b.dataset.id;
+      if (b.dataset.pin === '1') { pending = id; pinRow.classList.remove('hidden'); m.querySelector('#pf-id-pin').focus(); }
+      else doPick(id);
+    }));
+    m.querySelector('#pf-id-pinok').addEventListener('click', () => pending && doPick(pending, m.querySelector('#pf-id-pin').value));
+    m.querySelector('#pf-id-pin').addEventListener('keydown', (e) => { if (e.key === 'Enter') m.querySelector('#pf-id-pinok').click(); });
+    m.querySelector('#pf-id-add').addEventListener('click', () => (me && me.role === 'Owner') ? openInvite() : openCreateFirst(true));
+    m.querySelector('#pf-id-cancel').addEventListener('click', closeModal);
+  }
+
+  function openCreateFirst(asTeammate) {
+    const m = openModal(`
+      <h2>${asTeammate ? 'Create your profile' : 'Welcome to PuzzleForge'}</h2>
+      <p class="pf-id-sub">${asTeammate ? 'Add yourself to the team.' : "Let's set up your profile. The first person is the Owner."}</p>
+      ${field('Your name', 'pf-id-name', 'placeholder="e.g. Lyle" maxlength="80"')}
+      ${field('Email (optional)', 'pf-id-email', 'type="email" maxlength="160"')}
+      ${field('Pen name / author name (optional)', 'pf-id-pen', 'placeholder="Shown on your books" maxlength="120"')}
+      ${field('PIN (optional)', 'pf-id-pin2', 'type="password" inputmode="numeric" placeholder="Leave blank for none"')}
+      <p class="pf-id-err" id="pf-id-err"></p>
+      <div class="pf-id-modal-foot"><button id="pf-id-create" class="primary" type="button">Create profile</button><button id="pf-id-cancel" class="ghost" type="button">Cancel</button></div>`);
+    m.querySelector('#pf-id-create').addEventListener('click', async () => {
+      const body = { name: m.querySelector('#pf-id-name').value, email: m.querySelector('#pf-id-email').value, penName: m.querySelector('#pf-id-pen').value, pin: m.querySelector('#pf-id-pin2').value };
+      try { finishSignIn(await api('POST', '/profiles', body)); }
+      catch (err) { m.querySelector('#pf-id-err').textContent = err.message; }
+    });
+    m.querySelector('#pf-id-cancel').addEventListener('click', closeModal);
+    m.querySelector('#pf-id-name').focus();
+  }
+
+  async function openInvite() {
+    const m = openModal(`
+      <h2>Invite someone to the team</h2>
+      <p class="pf-id-sub">Create a link they open once to join. It works on your network and can only be used a single time.</p>
+      <label class="pf-id-field"><span>Their role</span><select id="pf-id-role">
+        <option>Editor</option><option>Writer</option><option>Illustrator</option><option>Reviewer</option><option>Contributor</option><option>Owner</option>
+      </select></label>
+      ${field('Their name (optional)', 'pf-id-iname', 'maxlength="80"')}
+      <label class="pf-id-field"><span>Invite link</span><input id="pf-id-link" readonly placeholder="Click Generate"></label>
+      <p class="pf-id-err" id="pf-id-err"></p>
+      <div class="pf-id-modal-foot"><button id="pf-id-gen" class="primary" type="button">Generate link</button><button id="pf-id-copy" class="ghost" type="button" disabled>Copy</button><button id="pf-id-cancel" class="ghost" type="button">Close</button></div>`);
+    m.querySelector('#pf-id-gen').addEventListener('click', async () => {
+      try {
+        const r = await api('POST', '/invites', { role: m.querySelector('#pf-id-role').value, name: m.querySelector('#pf-id-iname').value });
+        const url = `${location.origin}/profile.html?invite=${encodeURIComponent(r.token)}`;
+        m.querySelector('#pf-id-link').value = url;
+        m.querySelector('#pf-id-copy').disabled = false;
+      } catch (err) { m.querySelector('#pf-id-err').textContent = err.message; }
+    });
+    m.querySelector('#pf-id-copy').addEventListener('click', () => { const i = m.querySelector('#pf-id-link'); i.select(); try { navigator.clipboard.writeText(i.value); } catch (_) { document.execCommand('copy'); } m.querySelector('#pf-id-copy').textContent = 'Copied!'; });
+    m.querySelector('#pf-id-cancel').addEventListener('click', closeModal);
+  }
+
+  async function openJoin(inviteToken) {
+    let inv = null;
+    try { inv = await api('GET', '/invites/' + encodeURIComponent(inviteToken)); } catch (_) {}
+    if (!inv) return openModal(`<h2>Invite not valid</h2><p class="pf-id-sub">This invite link is invalid or has already been used. Ask the owner for a new one.</p><div class="pf-id-modal-foot"><button id="pf-id-cancel" class="primary" type="button">OK</button></div>`).querySelector('#pf-id-cancel').addEventListener('click', closeModal);
+    const m = openModal(`
+      <h2>Join the team${inv.by ? ` — invited by ${esc(inv.by)}` : ''}</h2>
+      <p class="pf-id-sub">You'll join as <b>${esc(inv.role)}</b>. Set up your profile:</p>
+      ${field('Your name', 'pf-id-name', `value="${esc(inv.name || '')}" maxlength="80"`)}
+      ${field('Email (optional)', 'pf-id-email', 'type="email" maxlength="160"')}
+      ${field('Pen name / author name (optional)', 'pf-id-pen', 'maxlength="120"')}
+      ${field('PIN (optional)', 'pf-id-pin2', 'type="password" inputmode="numeric" placeholder="Leave blank for none"')}
+      <p class="pf-id-err" id="pf-id-err"></p>
+      <div class="pf-id-modal-foot"><button id="pf-id-join" class="primary" type="button">Join &amp; sign in</button></div>`);
+    m.querySelector('#pf-id-join').addEventListener('click', async () => {
+      const body = { name: m.querySelector('#pf-id-name').value, email: m.querySelector('#pf-id-email').value, penName: m.querySelector('#pf-id-pen').value, pin: m.querySelector('#pf-id-pin2').value };
+      try {
+        finishSignIn(await api('POST', '/invites/' + encodeURIComponent(inviteToken) + '/accept', body));
+        // Drop the ?invite= from the URL so a refresh doesn't re-trigger it.
+        history.replaceState(null, '', location.pathname);
+      } catch (err) { m.querySelector('#pf-id-err').textContent = err.message; }
+    });
+    m.querySelector('#pf-id-name').focus();
+  }
+
+  function finishSignIn(res) {
+    if (res && res.token) setToken(res.token);
+    me = (res && res.profile) || null;
+    closeModal(); renderChip();
+    document.dispatchEvent(new CustomEvent('pf-identity', { detail: me }));
+  }
+  async function signOut() {
+    try { await api('DELETE', '/session'); } catch (_) {}
+    setToken(''); me = null; renderChip();
+    document.dispatchEvent(new CustomEvent('pf-identity', { detail: null }));
+    if (chip) chip.classList.remove('open');
+  }
+
+  async function refresh() {
+    try { const r = await api('GET', '/me'); me = r.profile || null; if (!me) setToken(''); }
+    catch (_) { me = null; }
+    renderChip();
+    if (!ready) { ready = true; readyCbs.splice(0).forEach((cb) => { try { cb(me); } catch (_) {} }); }
+    document.dispatchEvent(new CustomEvent('pf-identity', { detail: me }));
+    return me;
+  }
+
+  window.PFIdentity = {
+    me: () => me,
+    token,
+    authHeaders,
+    onReady: (cb) => { ready ? cb(me) : readyCbs.push(cb); },
+    refresh,
+    signOut,
+    openSignIn,
+  };
+
+  function boot() {
+    mountChip();
+    // Only auto-open the join flow for a real workspace invite token (48 hex
+    // chars). The Page Editor has its own legacy base64 ?invite= links — leave
+    // those to it so the two don't collide.
+    const inv = new URLSearchParams(location.search).get('invite');
+    refresh().then(() => { if (inv && /^[a-f0-9]{48}$/i.test(inv)) openJoin(inv); });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
+})();

--- a/publisher/public/library.js
+++ b/publisher/public/library.js
@@ -1,0 +1,109 @@
+/**
+ * PuzzleForge book library — client-side persistence in IndexedDB.
+ *
+ * Books are stored in this browser (no server round-trip), so a recipe with
+ * embedded image data URIs fits comfortably. Shared by the editor (autosave)
+ * and the My Books dashboard. UMD-ish: exposes window.PFLibrary.
+ *
+ * Record shape: { id, title, subtitle, trimSize, pages, createdAt, updatedAt, recipe }
+ */
+(function () {
+  const DB = 'pf-library';
+  const STORE = 'books';
+  let dbp = null;
+
+  function open() {
+    if (dbp) return dbp;
+    dbp = new Promise((res, rej) => {
+      let req;
+      try { req = indexedDB.open(DB, 1); } catch (e) { rej(e); return; }
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
+      };
+      req.onsuccess = () => res(req.result);
+      req.onerror = () => rej(req.error);
+    });
+    return dbp;
+  }
+
+  function list() {
+    return open().then((db) => new Promise((res, rej) => {
+      const req = db.transaction(STORE).objectStore(STORE).getAll();
+      req.onsuccess = () => res((req.result || []).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0)));
+      req.onerror = () => rej(req.error);
+    }));
+  }
+
+  function get(id) {
+    return open().then((db) => new Promise((res, rej) => {
+      const req = db.transaction(STORE).objectStore(STORE).get(id);
+      req.onsuccess = () => res(req.result || null);
+      req.onerror = () => rej(req.error);
+    }));
+  }
+
+  function put(rec) {
+    rec.updatedAt = Date.now();
+    if (!rec.createdAt) rec.createdAt = rec.updatedAt;
+    return open().then((db) => new Promise((res, rej) => {
+      const t = db.transaction(STORE, 'readwrite');
+      t.objectStore(STORE).put(rec);
+      t.oncomplete = () => res(rec);
+      t.onerror = () => rej(t.error);
+      t.onabort = () => rej(t.error);
+    }));
+  }
+
+  function remove(id) {
+    return open().then((db) => new Promise((res, rej) => {
+      const t = db.transaction(STORE, 'readwrite');
+      t.objectStore(STORE).delete(id);
+      t.oncomplete = () => res();
+      t.onerror = () => rej(t.error);
+    }));
+  }
+
+  const newId = () => 'bk_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+
+  // Build a library record's metadata from a recipe (for card display).
+  function metaFromRecipe(recipe) {
+    const book = (recipe && recipe.book) || {};
+    const pages = Array.isArray(recipe && recipe.pagePlan) ? recipe.pagePlan.length : null;
+    return { title: book.title || 'Untitled book', subtitle: book.subtitle || '', trimSize: book.trimSize || '', pages };
+  }
+
+  window.PFLibrary = { list, get, put, remove, newId, metaFromRecipe };
+
+  // --- Team workspace client (talks to the self-hosted LAN server) ---------
+  const WS = '/api/workspace';
+  const token = () => { try { return localStorage.getItem('pf_ws_token') || ''; } catch (_) { return ''; } };
+  function headers(json) { const h = {}; if (json) h['Content-Type'] = 'application/json'; const t = token(); if (t) h['x-pf-workspace'] = t; return h; }
+  async function ws(method, url, body) {
+    const r = await fetch(WS + url, { method, headers: headers(!!body), body: body ? JSON.stringify(body) : undefined });
+    if (r.status === 401) { const e = new Error('This workspace needs a token.'); e.needsToken = true; throw e; }
+    if (!r.ok) throw new Error(((await r.json().catch(() => ({}))) || {}).error || 'Workspace error');
+    return r.json();
+  }
+  window.PFWorkspace = {
+    status: () => fetch(WS + '/status').then((r) => (r.ok ? r.json() : { enabled: false })).catch(() => ({ enabled: false })),
+    members: () => ws('GET', '/members'),
+    addMember: (m) => ws('POST', '/members', m),
+    removeMember: (id) => ws('DELETE', '/members/' + id),
+    books: () => ws('GET', '/books'),
+    getBook: (id) => ws('GET', '/books/' + id),
+    shareBook: (id, recipe, by) => ws('PUT', '/books/' + id, { recipe, by }),
+    removeBook: (id) => ws('DELETE', '/books/' + id),
+    comments: (id) => ws('GET', '/books/' + id + '/comments'),
+    addComment: (id, c) => ws('POST', '/books/' + id + '/comments', c),
+    setToken: (t) => { try { localStorage.setItem('pf_ws_token', t || ''); } catch (_) {} },
+    subscribe: (onEvt) => {
+      const t = token();
+      let es;
+      try { es = new EventSource(WS + '/events' + (t ? '?token=' + encodeURIComponent(t) : '')); }
+      catch (_) { return { close() {} }; }
+      es.onmessage = (e) => { try { onEvt(JSON.parse(e.data)); } catch (_) {} };
+      return es;
+    },
+  };
+})();

--- a/publisher/public/starter-recipe.json
+++ b/publisher/public/starter-recipe.json
@@ -1,0 +1,13 @@
+{
+  "title": "Animal Adventures",
+  "subtitle": "A Mixed Puzzle Activity Book",
+  "author": "PuzzleForge",
+  "audience": "kids",
+  "trimSize": "8x10",
+  "theme": "animals",
+  "answerKey": true,
+  "puzzles": [
+    { "type": "wordsearch", "count": 3, "difficulty": 1 },
+    { "type": "sudoku", "count": 3, "difficulty": "3-4" }
+  ]
+}

--- a/publisher/public/styles.css
+++ b/publisher/public/styles.css
@@ -1,0 +1,1211 @@
+/* Nova Form Studios brand fonts (design system: Space Grotesk / Manrope / JetBrains Mono). */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  /* ---- Nova Form Studios palette — warm paper neutrals + teal→green brand ---- */
+  --nf-teal-50:#eafbf9; --nf-teal-100:#cdf3ee; --nf-teal-300:#5fd9cd; --nf-teal-500:#0fb5a6; --nf-teal-600:#0c9689; --nf-teal-700:#0a7a70; --nf-teal-900:#0a3d38;
+  --nf-green-100:#dff5cf; --nf-green-500:#5fcb6a; --nf-green-600:#46ab53; --nf-green-700:#338341;
+  --nf-neutral-0:#ffffff; --nf-neutral-25:#fafaf8; --nf-neutral-50:#f4f3ef; --nf-neutral-100:#e9e7e0; --nf-neutral-150:#e2dfd6; --nf-neutral-200:#d8d5cb; --nf-neutral-300:#bcb8ab; --nf-neutral-400:#948f80; --nf-neutral-500:#706b5e; --nf-neutral-600:#57534a; --nf-neutral-700:#423f38; --nf-neutral-900:#17160f;
+  --nf-red-500:#d64545; --nf-red-100:#fbe3e3; --nf-amber-500:#d69a2d; --nf-amber-100:#fbf0dc; --nf-blue-500:#3b7dd8; --nf-blue-100:#e2edfb;
+  --nf-gradient-brand: linear-gradient(135deg, var(--nf-teal-500) 0%, var(--nf-green-500) 100%);
+  --nf-gradient-brand-soft: linear-gradient(135deg, var(--nf-teal-100) 0%, var(--nf-green-100) 100%);
+
+  /* type */
+  --font-display:'Space Grotesk','Arial Narrow',sans-serif;
+  --font-body:'Manrope',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  --font-mono:'JetBrains Mono','SFMono-Regular',Consolas,monospace;
+
+  /* radius / shadow */
+  --radius-sm:6px; --radius-md:10px; --radius-lg:16px; --radius-pill:999px;
+  --shadow-xs:0 1px 2px rgba(23,22,15,.06); --shadow-sm:0 2px 8px rgba(23,22,15,.07); --shadow-md:0 8px 24px rgba(23,22,15,.09);
+  --focus-ring:0 0 0 3px rgba(15,181,166,.35);
+
+  /* ---- Legacy semantic names remapped onto the brand (existing rules pick these up) ---- */
+  --bg: var(--nf-neutral-25);
+  --panel: var(--nf-neutral-0);
+  --ink: var(--nf-neutral-900);
+  --muted: var(--nf-neutral-500);
+  --line: var(--nf-neutral-150);
+  --brand: var(--nf-teal-500);
+  --brand-dark: var(--nf-teal-600);
+  --ok: var(--nf-green-700);
+  --text: var(--nf-neutral-700);   /* default body text */
+  --field-bg: var(--nf-neutral-25); /* input/select surface */
+  --hover-bg: var(--nf-neutral-50); /* subtle hover fill */
+}
+
+/* ---- Nova Form dark theme (teacher web app). Keyed off <html data-theme>,
+   distinct from the editor's own body.theme-dark skin. Auto-follows the OS
+   unless the user has explicitly picked a theme. ---- */
+:root[data-theme="dark"],
+:root[data-theme="dark"] body {
+  --bg:#14130e; --panel:#1f1d17; --ink:#f5f3ef; --muted:#a8a293; --line:#33302a;
+  --brand:#1fc9ba; --brand-dark:#4fe0d0; --ok:#7dd69a;
+  --text:#d6d2c7; --field-bg:#26241d; --hover-bg:#2c2a22;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg:#14130e; --panel:#1f1d17; --ink:#f5f3ef; --muted:#a8a293; --line:#33302a;
+    --brand:#1fc9ba; --brand-dark:#4fe0d0; --ok:#7dd69a;
+    --text:#d6d2c7; --field-bg:#26241d; --hover-bg:#2c2a22;
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar {
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.nav { display: flex; gap: 6px; }
+.nav a {
+  text-decoration: none; color: var(--muted); font-size: 14px; font-weight: 600;
+  padding: 8px 14px; border-radius: 9px;
+}
+.nav a:hover { background: var(--hover-bg); }
+.nav a.active { background: var(--nf-gradient-brand-soft); color: var(--nf-teal-700); }
+.theme-toggle {
+  margin-left: 4px; width: 38px; height: 38px; padding: 0; border-radius: var(--radius-pill);
+  background: var(--panel); border: 1px solid var(--nf-neutral-300); color: var(--ink);
+  font-size: 16px; line-height: 1; cursor: pointer; flex: none;
+}
+.theme-toggle:hover { background: var(--hover-bg); transform: translateY(-1px); }
+/* Dark-mode fixes for elements that hardcode light fills */
+:root[data-theme="dark"] .tpl-cta { background: linear-gradient(120deg,#12302c,#173021); border-color:#1d5049; }
+:root[data-theme="dark"] .aud-badge.aud-kids { background:#173021; color:#8fe0a4; }
+:root[data-theme="dark"] .aud-badge.aud-adult { background:#123249; color:#8fc0f0; }
+:root[data-theme="dark"] .aud-badge.aud-both { background:#2c2a22; color:#bcb8ab; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .tpl-cta { background: linear-gradient(120deg,#12302c,#173021); border-color:#1d5049; }
+}
+.brand { display: flex; align-items: center; gap: 14px; }
+.brand .logo {
+  font-size: 26px; color: #fff;
+  background: var(--nf-gradient-brand); width: 48px; height: 48px; border-radius: 14px;
+  display: flex; align-items: center; justify-content: center; box-shadow: var(--shadow-xs);
+}
+.brand h1 { margin: 0; font-size: 20px; letter-spacing: -.01em; font-family: var(--font-display); color: var(--ink); }
+.brand .tagline { margin: 2px 0 0; color: var(--muted); font-size: 13px; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 380px 1fr;
+  gap: 20px;
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+  align-items: start;
+}
+@media (max-width: 860px) { .layout { grid-template-columns: 1fr; } }
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+.panel h2 {
+  font-family: var(--font-display);
+  font-size: 13px; text-transform: uppercase; letter-spacing: .08em;
+  color: var(--muted); margin: 18px 0 10px;
+}
+.panel h2:first-of-type { margin-top: 0; }
+
+.field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 12px; }
+.field > span { font-size: 13px; color: var(--muted); }
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+select, input[type="text"], input[type="number"], input[type="url"], input[type="email"], textarea {
+  font: inherit;
+  padding: 9px 11px;
+  border: 1px solid var(--nf-neutral-200);
+  border-radius: var(--radius-md);
+  background: var(--field-bg);
+  color: var(--ink);
+  width: 100%;
+}
+textarea { resize: vertical; }
+select:focus, input:focus, textarea:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--brand); }
+
+.words-source {
+  border: 1px solid var(--line); border-radius: 11px; padding: 12px; margin: 0 0 12px;
+}
+.words-source legend { font-size: 12px; color: var(--muted); padding: 0 6px; }
+.radio { display: inline-flex; align-items: center; gap: 6px; font-size: 14px; margin-right: 14px; }
+
+.actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+button, .upload {
+  font: inherit; font-weight: 600; cursor: pointer; border-radius: var(--radius-pill); padding: 9px 18px; border: 1px solid transparent;
+  transition: background var(--duration-fast,120ms) ease, transform var(--duration-fast,120ms) ease;
+}
+button.primary { background: var(--brand); color: #fff; border-color: var(--brand); }
+button.primary:hover:not(:disabled) { background: var(--brand-dark); transform: translateY(-1px); }
+button.ghost, .upload { background: var(--panel); border-color: var(--nf-neutral-300); color: var(--ink); }
+button.ghost:hover:not(:disabled), .upload:hover { background: var(--hover-bg); transform: translateY(-1px); }
+button:disabled { background: var(--nf-neutral-100); color: var(--nf-neutral-400); border-color: var(--nf-neutral-100); cursor: not-allowed; }
+.checkbox { display: inline-flex; align-items: center; gap: 6px; font-size: 14px; color: var(--muted); }
+
+.status { font-size: 13px; min-height: 18px; margin: 4px 0 0; }
+.status.ok { color: var(--ok); }
+.status.err { color: #c92a2a; }
+.status.busy { color: var(--muted); }
+/* Indeterminate progress bar (AI generators — unknown duration) */
+.pf-progress { height: 6px; border-radius: var(--radius-pill); background: var(--line); overflow: hidden; margin: 10px 0 2px; }
+.pf-progress[hidden] { display: none; }
+.pf-progress-bar { height: 100%; width: 40%; border-radius: inherit; background: var(--nf-gradient-brand); animation: pf-indeterminate 1.15s ease-in-out infinite; }
+@keyframes pf-indeterminate { 0% { margin-left: -42%; } 100% { margin-left: 100%; } }
+@media (prefers-reduced-motion: reduce) { .pf-progress-bar { animation-duration: 2.4s; } }
+
+.hint { font-size: 12px; color: var(--muted); line-height: 1.5; margin-top: 8px; }
+.hint.ok { color: var(--ok); }
+.hint.err { color: #c92a2a; }
+.aud-badge { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .3px; padding: 1px 6px; border-radius: 999px; vertical-align: middle; }
+.aud-badge.aud-kids { background: #e6f4ea; color: #1e7e34; }
+.aud-badge.aud-adult { background: #e7eefc; color: #2a5db0; }
+.aud-badge.aud-both { background: #eee; color: #555; }
+.theme-dark .aud-badge.aud-kids { background: #1e3a29; color: #7ee2a8; }
+.theme-dark .aud-badge.aud-adult { background: #1e2c4a; color: #8fb4f2; }
+.theme-dark .aud-badge.aud-both { background: #333; color: #bbb; }
+.hidden { display: none !important; }
+
+.clue-editor { border: 1px solid var(--line); border-radius: 11px; padding: 10px 12px; margin: 0 0 12px; }
+.clue-editor summary { cursor: pointer; font-size: 14px; color: var(--ink); }
+.clue-list { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; max-height: 240px; overflow: auto; }
+.clue-row { display: grid; grid-template-columns: 100px 1fr; gap: 8px; align-items: center; }
+.clue-row .w { font-weight: 700; font-size: 13px; letter-spacing: .5px; }
+.clue-row input { padding: 6px 8px; font-size: 13px; }
+
+.tool { border: 1px solid var(--line); border-radius: 11px; padding: 12px; margin-bottom: 10px; }
+.tool-head { display: flex; flex-direction: column; margin-bottom: 8px; }
+.tool-head strong { font-size: 14px; }
+.tool-desc { font-size: 12px; color: var(--muted); }
+.inline { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--muted); }
+.inline input { width: 64px; }
+.inline select { width: auto; }
+
+.checkbox-field { justify-content: flex-end; }
+.rows { display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px; }
+.prow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 52px 84px minmax(0, 1.1fr) auto;
+  gap: 6px;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 6px;
+}
+.prow select, .prow input { padding: 7px 8px; font-size: 13px; }
+.prow .move { display: flex; flex-direction: column; gap: 1px; }
+.prow .iconbtn {
+  border: 1px solid var(--line); background: var(--panel); border-radius: 6px;
+  padding: 1px 6px; font-size: 12px; line-height: 1.3; cursor: pointer; color: var(--muted);
+}
+.prow .iconbtn:hover { background: var(--hover-bg); }
+.prow .del { color: #c92a2a; }
+
+.preview { position: sticky; top: 20px; }
+.preview-head { display: flex; align-items: center; justify-content: space-between; }
+.tabs { display: inline-flex; background: var(--nf-neutral-100); border-radius: var(--radius-pill); padding: 3px; }
+.tab { background: transparent; border: none; padding: 6px 14px; border-radius: var(--radius-pill); font-size: 13px; color: var(--muted); }
+.tab.active { background: var(--panel); color: var(--nf-teal-700); box-shadow: var(--shadow-xs); }
+
+.preview-frame {
+  position: relative;
+  margin-top: 12px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  overflow: hidden;
+  background: var(--panel);
+  min-height: 70vh;
+}
+.preview-frame iframe { width: 100%; height: 70vh; border: 0; display: block; background: #fff; }
+.empty {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  color: var(--muted); text-align: center; padding: 24px; background: var(--panel);
+}
+.empty.hidden { display: none; }
+
+/* Image-tools preview */
+.img-preview { display: flex; align-items: center; justify-content: center; padding: 12px; background: #fff; }
+.img-preview > img { max-width: 100%; max-height: 76vh; }
+
+/* Image Tools sub-tabs */
+.tools-tabs { margin-bottom: 16px; }
+
+/* Color-by-number preview */
+.cbn-preview { width: 100%; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.cbn-preview.hidden { display: none; }
+.cbn-preview .artwrap { position: relative; display: inline-block; max-width: 100%; }
+.cbn-preview .artwrap img { display: block; max-width: 100%; max-height: 64vh; }
+.cbn-preview .n { position: absolute; transform: translate(-50%, -50%); font-size: 9px; color: #555; line-height: 1; pointer-events: none; }
+.cbn-preview .keyrow { display: flex; flex-wrap: wrap; gap: 6px 14px; justify-content: center; }
+.cbn-preview .key { display: flex; align-items: center; gap: 5px; font-size: 13px; }
+.cbn-preview .sw { width: 16px; height: 16px; border: 1px solid #000; display: inline-block; }
+.cbn-preview .kn { font-weight: 700; }
+.cbn-preview .ref { text-align: center; }
+.cbn-preview .ref img { max-height: 22vh; max-width: 60%; border: 1px solid #ccc; }
+.cbn-preview .ref-cap { font-size: 12px; color: #666; }
+
+/* Dot-to-dot preview */
+.dots-preview .dots-instr { font-size: 14px; }
+.dots-preview .artwrap img { max-height: 60vh; }
+.dots-preview .dot { position: absolute; width: 5px; height: 5px; background: #000; border-radius: 50%; transform: translate(-50%, -50%); }
+.dots-preview .dn { position: absolute; font-size: 10px; color: #000; transform: translate(5px, -120%); line-height: 1; }
+
+/* Cover Builder preview */
+.cover-frame { min-height: 40vh; padding: 12px; overflow: auto; }
+.cover-scale { transform-origin: top left; }
+.cover-scale iframe { border: 1px solid var(--line); background: #fff; display: block; }
+
+/* Theme search/filter box above a theme picker */
+.theme-filter { margin-bottom: 6px; font-size: 13px; padding: 7px 9px; }
+
+/* "Between puzzles, insert" control */
+.interleave {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 14px;
+  border: 1px solid var(--line); border-radius: 11px; padding: 10px 12px; margin-top: 8px;
+}
+.interleave-label { font-size: 13px; color: var(--muted); }
+
+/* Front-matter fieldset */
+.matter { border: 1px solid var(--line); border-radius: 11px; padding: 12px; margin: 12px 0; }
+.matter legend { font-size: 12px; color: var(--muted); padding: 0 6px; }
+.matter .checkbox { display: flex; margin-bottom: 6px; }
+.matter .field { margin-top: 8px; margin-bottom: 0; }
+
+/* AI theme generator */
+.banner {
+  background: #fff7ed; border: 1px solid #fed7aa; color: #9a3412;
+  border-radius: 10px; padding: 10px 12px; font-size: 13px; margin: 0 0 12px;
+}
+.banner code { background: #ffedd5; padding: 1px 5px; border-radius: 5px; }
+
+/* Worksheets & lesson packets */
+.pk-autoplan { background: var(--hover-bg); border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; margin-bottom: 18px; }
+.pk-autoplan h2 { border: 0; padding: 0; }
+#pkStandardsHint { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; font-size: 12px; line-height: 1.5; }
+.ws-preview-frame { border: 1px solid var(--line); border-radius: 10px; overflow: auto; background: #fff; }
+.ws-preview-frame.hidden { display: none; }
+.ws-preview-scale { transform-origin: top left; }
+#wsPreview { border: 0; background: #fff; display: block; }
+.ws-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+.ws-row select { flex: 1; min-width: 0; }
+.ws-row .iconbtn.del { flex: none; border: 1px solid var(--line); background: var(--panel); color: #c92a2a; border-radius: 7px; padding: 7px 10px; }
+
+/* Book Builder — low word-pool warning (before "No repeated words" generation) */
+.pool-warn { margin: 12px 0 0; padding: 11px 13px; border-radius: 10px; font-size: 13px;
+  background: #fff7ed; border: 1px solid #fed7aa; color: #7c3a12; }
+.pool-warn-head { font-weight: 700; margin-bottom: 6px; }
+.pool-warn-list { margin: 0 0 8px; padding-left: 18px; display: grid; gap: 3px; }
+.pool-warn-fix { font-size: 12px; opacity: .92; }
+.pool-warn a { color: inherit; text-decoration: underline; font-weight: 600; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .pool-warn { background: #2e2718; border-color: #5a4415; color: #f0cf9a; }
+}
+:root[data-theme="dark"] .pool-warn { background: #2e2718; border-color: #5a4415; color: #f0cf9a; }
+.tagrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.tag {
+  font-size: 12px; color: var(--brand); background: #eef1fe;
+  border-radius: 999px; padding: 2px 10px; font-weight: 600;
+}
+.tier-block { margin: 8px 0; }
+.tier-block strong { font-size: 13px; }
+.tier-words { font-size: 12px; color: var(--muted); line-height: 1.6; margin: 4px 0 0; }
+.explainer { padding: 4px 4px 0; color: var(--ink); }
+.explainer ol { margin: 0 0 8px; padding-left: 20px; }
+.explainer li { margin-bottom: 10px; font-size: 14px; line-height: 1.5; }
+.explainer code { background: #eef1fe; padding: 1px 5px; border-radius: 5px; font-size: 13px; }
+
+/* Per-page drawing/coloring subject editor */
+.edit-panel { margin-top: 14px; }
+.edit-panel.hidden { display: none; }
+.edit-panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); margin: 0 0 4px; }
+.edit-row { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+.edit-row .edit-label { flex: 1; font-size: 13px; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.edit-row input { width: 160px; padding: 6px 8px; font-size: 13px; }
+
+/* Theme editor (remove words / facts) */
+.theme-editor { margin-top: 16px; }
+.theme-editor.hidden { display: none; }
+.editor-block { margin: 10px 0; }
+.editor-block strong { font-size: 13px; }
+.editor-expand { display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 10px 12px; margin: 0 0 6px; background: var(--hover-bg); border: 1px solid var(--line); border-radius: 9px; }
+.editor-expand-target { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+.editor-expand-target input { width: 58px; padding: 4px 6px; border: 1px solid var(--line); border-radius: 6px;
+  background: var(--field-bg); color: var(--ink); }
+.chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.chip { display: inline-flex; align-items: center; gap: 6px; background: var(--nf-teal-50); color: var(--nf-teal-900);
+  border-radius: 999px; padding: 3px 6px 3px 10px; font-size: 13px; }
+.chip.chip-wide { border-radius: 9px; align-items: flex-start; padding: 6px 6px 6px 10px; max-width: 100%; }
+.chip-x { border: none; background: var(--nf-teal-100); color: var(--nf-teal-700); border-radius: 999px; cursor: pointer;
+  width: 18px; height: 18px; line-height: 1; font-size: 11px; padding: 0; flex: 0 0 auto; }
+.chip-x:hover { background: var(--nf-red-500); color: #fff; }
+/* Dark: keep chips readable (nf-teal-50 is a fixed light tint) */
+:root[data-theme="dark"] .chip { background: rgba(15,181,166,.16); color: var(--nf-teal-100); }
+:root[data-theme="dark"] .chip-x { background: rgba(15,181,166,.28); color: var(--nf-teal-100); }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .chip { background: rgba(15,181,166,.16); color: var(--nf-teal-100); }
+  :root:not([data-theme="light"]) .chip-x { background: rgba(15,181,166,.28); color: var(--nf-teal-100); }
+}
+.fact-edit-list { display: flex; flex-direction: column; gap: 6px; margin-top: 6px; }
+
+/* ===== Ribbon toolbar (Page Editor, MS Publisher style) ===== */
+.ribbon { background: var(--panel); border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 50; }
+.ribbon-title { display: flex; align-items: center; gap: 18px; padding: 8px 18px 6px; }
+.ribbon-title .brand .logo { width: 40px; height: 40px; font-size: 24px; border-radius: 10px; }
+.ribbon-title .brand h1 { font-size: 17px; }
+.ribbon-title .brand .tagline { font-size: 12px; }
+.ribbon-qa { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+
+.ribbon-tabs { display: flex; gap: 2px; padding: 0 14px; border-bottom: 1px solid var(--line); }
+.rtab { border: none; background: transparent; padding: 7px 16px; margin-bottom: -1px; font-size: 13px; font-weight: 600;
+  color: var(--muted); cursor: pointer; border: 1px solid transparent; border-bottom: none; border-radius: 8px 8px 0 0; }
+.rtab:hover { background: #f1f3f9; color: var(--ink); }
+.rtab.active { color: var(--brand); background: var(--panel); border-color: var(--line); }
+/* Contextual tab (Publisher-style): hidden from the strip until the related
+   object is selected, then revealed with .avail. */
+.rtab-context { color: #b4690e; display: none; }
+.rtab-context.avail { display: inline-block; }
+.rtab-context.active { color: #b4690e; background: #fff7ee; border-color: #f0d8b8; }
+
+.ribbon-body { background: linear-gradient(#fbfbfd, #f3f4f8); min-height: 94px; padding: 8px 12px; overflow-x: auto; overflow-y: hidden; }
+.ribbon-panel { display: none; align-items: stretch; }
+.ribbon-panel.active { display: flex; }
+.ribbon-inline { display: flex; }
+
+.rgroup { display: flex; flex-direction: column; padding: 2px 7px; border-right: 1px solid var(--line); }
+.rgroup:last-child { border-right: none; }
+.rgroup-body { display: flex; align-items: center; gap: 6px; flex: 1; flex-wrap: wrap; }
+.rgroup-body.col { flex-direction: column; align-items: flex-start; gap: 5px; }
+.rgroup-body.wide { min-width: 210px; }
+.rgroup-name { font-size: 11px; color: var(--muted); text-align: center; padding-top: 5px; white-space: nowrap; }
+
+.ribbon .field.compact { margin: 0; width: 100%; }
+.ribbon .field.compact > span { font-size: 11px; margin-bottom: 3px; }
+.ribbon .m { display: flex; flex-direction: column; gap: 2px; }
+.ribbon .m > span { font-size: 11px; color: var(--muted); }
+.ribbon .m input, .ribbon .m select { padding: 5px 6px; font-size: 13px; width: 76px; }
+.ribbon .m input[type=color] { width: 44px; height: 30px; padding: 2px; }
+.ribbon .align-grid { margin: 0; }
+.ribbon .mini { padding: 5px 6px; font-size: 12px; max-width: 96px; }
+.ribbon .mini-num { width: 52px; padding: 5px 6px; font-size: 12px; }
+.ribbon .mini-color { width: 34px; height: 28px; padding: 2px; }
+.qa-sep { width: 1px; align-self: stretch; background: var(--line); margin: 4px 4px; }
+.shape-mini { display: inline-flex; gap: 3px; }
+.palign.on, .ghost.on, .iconbtn.on, .fmtPainter.on { background: #eef1fe; border-color: var(--brand); color: var(--brand); }
+.theme-dark .palign.on, .theme-dark .ghost.on, .theme-dark .iconbtn.on { background: #2f3b57; border-color: var(--brand); color: #cdd6ff; }
+
+/* --- MS-Publisher-style ribbon buttons ---------------------------------
+   Flat (no pill border until hover). Two kinds:
+   • .rbig  — large, icon on top / label below (Paste, Objects, Wrap Text…)
+   • .rmini — small, icon left / label right; stacked 3-per-column so a group
+     stays narrow while keeping its labels. */
+.ribbon .rbig, .ribbon .rmini {
+  border: 1px solid transparent; border-radius: 5px; background: transparent;
+  color: var(--ink); cursor: pointer; white-space: nowrap; line-height: 1.15;
+  font-family: inherit;
+}
+.ribbon .rbig:hover, .ribbon .rmini:hover { background: #eef1fe; border-color: #dbe3ff; }
+.ribbon .rbig { display: inline-flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  min-width: 50px; max-width: 82px; min-height: 60px; padding: 4px 8px; font-size: 11px; text-align: center; }
+.ribbon .rbig .rbig-ico { font-size: 22px; line-height: 1; }
+.ribbon .rmini { display: inline-flex; align-items: center; gap: 6px; padding: 3px 7px; font-size: 12px; text-align: left; }
+.ribbon .rmini .rmini-ico { width: 16px; flex: none; text-align: center; font-size: 13px; }
+.ribbon .rmini.del { color: #c92a2a; }
+.ribbon .rbig .rdrop-caret, .ribbon .rmini .rdrop-caret { font-size: 9px; margin-left: 1px; }
+/* Small commands stacked in a column (Clipboard, Editing) or a 3-row grid
+   that fills column-first (Arrange, Page). */
+.ribbon .rmini-col { display: inline-flex; flex-direction: column; gap: 2px; justify-content: center; }
+.ribbon .rmini-grid { display: grid; grid-auto-flow: column; grid-template-rows: repeat(3, auto); gap: 2px 8px; align-content: center; }
+.ribbon .rmini-grid .rdrop { display: flex; }
+.ribbon .rmini-grid .rdrop .rmini, .ribbon .rmini-grid > .rmini { width: 100%; }
+.ribbon .rbig.on, .ribbon .rmini.on { background: #eef1fe; border-color: var(--brand); color: var(--brand); }
+.theme-dark .ribbon .rbig:hover, .theme-dark .ribbon .rmini:hover { background: #2f3b57; border-color: #3d4a63; }
+.theme-dark .ribbon .rbig.on, .theme-dark .ribbon .rmini.on { background: #2f3b57; border-color: var(--brand); color: #cdd6ff; }
+/* Flatten the Font/Paragraph toggle buttons to match (leave gallery icons alone). */
+.ribbon .iconbtn:not(.shape-btn) { background: transparent; border-color: transparent; }
+.ribbon .iconbtn:not(.shape-btn):hover { background: #eef1fe; border-color: #dbe3ff; }
+.theme-dark .ribbon .iconbtn:not(.shape-btn):hover { background: #2f3b57; border-color: #3d4a63; }
+.ribbon .iconbtn.on { background: #eef1fe; border-color: var(--brand); color: var(--brand); }
+.theme-dark .ribbon .iconbtn.on { background: #2f3b57; border-color: var(--brand); color: #cdd6ff; }
+/* Fixed widths so the control-heavy groups wrap into tidy 2-row blocks
+   instead of collapsing to one-control-per-row when flexbox hands them slack. */
+/* Publisher's Insert ribbon is a single row of tall icon-over-label buttons.
+   Keep each group's buttons on one line so the ribbon stays one row high. */
+.ribbon-panel[data-panel="insert"] .rgroup-body { flex-wrap: nowrap; }
+.ribbon-panel[data-panel="insert"] .rbig { min-width: 44px; max-width: 76px; padding: 3px 5px; }
+.ribbon-panel[data-panel="insert"] .rbig .rbig-ico { font-size: 20px; }
+/* Page Design is also a single row of tall icon-over-label buttons. */
+.ribbon-panel[data-panel="design"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="design"] .rbig { min-width: 46px; max-width: 84px; padding: 3px 6px; }
+.ribbon-panel[data-panel="design"] .rbig .rbig-ico { font-size: 20px; }
+.ribbon .rbig .rbig-aa { font-family: Georgia, 'Times New Roman', serif; font-size: 21px; font-weight: 600; }
+/* View tab is a single row of icon-over-label buttons too. */
+.ribbon-panel[data-panel="view"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="view"] .rbig { min-width: 46px; max-width: 84px; padding: 3px 6px; }
+.ribbon-panel[data-panel="view"] .rbig .rbig-ico { font-size: 20px; }
+.show-checks { display: grid; grid-template-columns: 1fr 1fr; gap: 2px 16px; }
+.show-checks .checkbox { font-size: 12.5px; }
+.ribbon-panel[data-panel="design"] .rmini-col.align-to { gap: 3px; }
+.ribbon-panel[data-panel="design"] .rmini-col.align-to .design-info { font-size: 11px; }
+.ribbon-panel[data-panel="design"] .rmini-col.align-to .checkbox { font-size: 12px; }
+/* Menu building blocks shared by the Margins / Background / Master dropdowns. */
+.rdrop-sep { height: 1px; background: var(--line); margin: 5px 4px; }
+.rdrop-note { padding: 5px 10px 2px; font-size: 12.5px; }
+.rdrop-hint { padding: 0 10px 8px; font-size: 11px; color: var(--muted); max-width: 220px; }
+.rdrop-check { display: flex; align-items: center; gap: 6px; padding: 6px 10px; font-size: 12.5px; cursor: pointer; }
+.rdrop-field { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 4px 10px; font-size: 12px; }
+.rdrop-field > span { color: var(--muted); }
+.rdrop-field select, .rdrop-field input { padding: 4px 6px; font-size: 12px; }
+.rdrop-field input[type=number] { width: 60px; }
+.rdrop-field input[type=color] { width: 40px; height: 26px; padding: 2px; }
+.rdrop-item { display: block; width: 100%; text-align: left; }
+/* Fonts gallery inside the Fonts dropdown. */
+.fonts-menu { width: 244px; }
+.fonts-list { max-height: 300px; overflow-y: auto; padding: 2px; }
+.font-cat { font-size: 10.5px; text-transform: uppercase; letter-spacing: .4px; color: var(--muted); padding: 8px 8px 3px; }
+.font-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 2px; border-radius: 6px; }
+.font-row.on { background: #eef1fe; }
+.theme-dark .font-row.on { background: #2f3b57; }
+.font-row-use { display: flex; align-items: baseline; gap: 10px; width: 100%; min-width: 0; padding: 6px 9px; text-align: left; overflow: hidden; }
+.font-row-aa { flex: 0 0 auto; font-size: 17px; line-height: 1; }
+.font-row-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; }
+.fonts-upload { display: block; padding: 8px 10px; font-size: 12.5px; cursor: pointer; border-radius: 6px; }
+.fonts-upload:hover { background: #eef1fe; color: var(--brand); }
+.theme-dark .fonts-upload:hover { background: #2f3b57; color: #cdd6ff; }
+.bg-menu { min-width: 190px; }
+.bg-type.on { background: #eef1fe; color: var(--brand); }
+.theme-dark .bg-type.on { background: #2f3b57; color: #cdd6ff; }
+.bg-colors { display: grid; gap: 2px; padding: 2px 0; }
+.ribbon .bb-border { width: 118px; margin: 0; }
+.ribbon .bb-border > span { font-size: 10px; margin-bottom: 2px; }
+.ribbon .font-body { width: 210px; align-content: center; gap: 4px 4px; }
+.ribbon .para-body { width: 100px; align-content: center; gap: 4px 4px; }
+/* Live page-border overlay (mirrors the printed .pf-frame from export.js). */
+.pf-frame { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
+.pf-frame svg { width: 100%; height: 100%; display: block; }
+.ribbon .ghost { padding: 6px 10px; font-size: 12px; white-space: nowrap; }
+.ribbon .del { color: #c92a2a; border-color: #f2c2c2; }
+.ribbon .zoombar { padding: 3px 5px; }
+.ribbon .checkbox { font-size: 13px; }
+.rhint { color: var(--muted); font-size: 13px; padding: 10px 8px; align-self: center; }
+
+/* Page Design tab */
+.design-info { font-size: 12px; color: var(--muted); font-weight: 600; }
+.scheme-gallery { display: flex; gap: 6px; flex-wrap: wrap; max-width: 340px; }
+.scheme-chip { display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 4px 5px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel, #fff); cursor: pointer; }
+.scheme-chip:hover { border-color: var(--brand); }
+.scheme-chip.active { border-color: var(--brand); box-shadow: 0 0 0 1px var(--brand) inset; }
+.scheme-sw { display: flex; width: 44px; height: 16px; border-radius: 3px; overflow: hidden; }
+.scheme-sw i { flex: 1; }
+.scheme-nm { font-size: 10px; color: var(--muted); }
+.theme-dark .scheme-chip { background: #34373d; }
+
+/* Review tab: thesaurus + word count */
+.syn-list { display: flex; flex-wrap: wrap; gap: 8px; }
+.syn-chip { padding: 7px 12px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel, #fff); cursor: pointer; font-size: 14px; }
+.syn-chip:hover { border-color: var(--brand); background: #eef1fe; color: var(--brand); }
+.theme-dark .syn-chip { background: #34373d; }
+.theme-dark .syn-chip:hover { background: #2f3b57; color: #cdd6ff; }
+.wc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+.wc-cell { display: flex; flex-direction: column; align-items: center; padding: 14px; border: 1px solid var(--line); border-radius: 8px; }
+.wc-cell b { font-size: 26px; }
+.wc-cell span { font-size: 12px; color: var(--muted); }
+
+/* Help Center */
+.pf-help { width: min(820px, 94vw); max-height: 88vh; display: flex; flex-direction: column; }
+.pf-help-search { width: 100%; padding: 9px 12px; font-size: 14px; border: 1px solid var(--line); border-radius: 8px; margin-bottom: 12px; }
+.pf-help-body { display: grid; grid-template-columns: 180px 1fr; gap: 14px; overflow: hidden; flex: 1; min-height: 0; }
+.pf-help-cats { display: flex; flex-direction: column; gap: 4px; overflow-y: auto; }
+.pf-help-cat { text-align: left; padding: 8px 10px; border: 1px solid transparent; border-radius: 7px; background: none; cursor: pointer; font-size: 13px; color: var(--ink); }
+.pf-help-cat:hover { background: var(--panel, #f2f4f8); }
+.pf-help-cat.active { background: #eef1fe; border-color: var(--brand); color: var(--brand); font-weight: 600; }
+.theme-dark .pf-help-cat:hover { background: #34373d; }
+.theme-dark .pf-help-cat.active { background: #2f3b57; color: #cdd6ff; }
+.pf-help-articles { overflow-y: auto; padding-right: 4px; }
+.pf-help-group { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); margin: 14px 0 6px; }
+.pf-help-group:first-child { margin-top: 0; }
+.pf-help-art { border: 1px solid var(--line); border-radius: 8px; margin-bottom: 8px; }
+.pf-help-art > summary { padding: 10px 12px; cursor: pointer; font-weight: 600; font-size: 14px; list-style: none; }
+.pf-help-art > summary::-webkit-details-marker { display: none; }
+.pf-help-art[open] > summary { border-bottom: 1px solid var(--line); }
+.pf-help-ans { padding: 10px 12px; font-size: 14px; line-height: 1.5; color: var(--ink); }
+.pf-help-ans code { background: var(--panel, #eef0f6); padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+.theme-dark .pf-help-ans code { background: #34373d; }
+.pf-help-foot { margin-top: 12px; font-size: 13px; color: var(--muted); }
+.linkbtn { background: none; border: none; color: var(--brand); cursor: pointer; font: inherit; padding: 0; text-decoration: underline; }
+
+/* Mailings: team roster + handoff notes */
+.pf-team-add { display: grid; grid-template-columns: 1.2fr 1.4fr 0.9fr auto; gap: 8px; margin-bottom: 12px; }
+.pf-team-add input, .pf-team-add select { padding: 7px 8px; border: 1px solid var(--line); border-radius: 7px; font-size: 13px; }
+.pf-team-list { display: flex; flex-direction: column; gap: 8px; max-height: 40vh; overflow-y: auto; }
+.pf-team-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 9px; flex-wrap: wrap; }
+.pf-team-who { font-size: 14px; line-height: 1.35; }
+.pf-team-acts { display: flex; gap: 5px; flex-wrap: wrap; }
+.pf-role { display: inline-block; color: #fff; font-size: 11px; font-weight: 700; padding: 1px 7px; border-radius: 999px; vertical-align: middle; }
+.pf-assigned { color: #2b8a3e; font-size: 12px; font-weight: 600; }
+.pf-dim { color: var(--muted); font-size: 12px; }
+.pf-help-note { margin-top: 14px; padding: 10px 12px; border-left: 3px solid var(--brand); background: rgba(123,147,255,.08); border-radius: 0 6px 6px 0; }
+.pf-notes-list { display: flex; flex-direction: column; gap: 8px; max-height: 44vh; overflow-y: auto; margin-bottom: 12px; }
+.pf-note { border: 1px solid var(--line); border-radius: 9px; padding: 9px 12px; }
+.pf-note-head { font-size: 13px; margin-bottom: 4px; }
+.pf-note-body { font-size: 14px; line-height: 1.45; white-space: pre-wrap; }
+.pf-notes-add { display: flex; gap: 8px; align-items: flex-end; }
+.pf-notes-add textarea { flex: 1; padding: 8px; border: 1px solid var(--line); border-radius: 7px; font: inherit; resize: vertical; }
+
+.ribbon-layout { grid-template-columns: 200px 1fr !important; max-width: none !important; }
+.ribbon-layout .editor-stage { min-height: 78vh; }
+
+/* ===== Dark skin (editor chrome only; the page/paper stays white) ===== */
+body.theme-dark {
+  --bg: #1e1f22; --panel: #2b2d31; --ink: #e6e8ee; --muted: #9aa2b1;
+  --line: #3a3d44; --brand: #7b93ff; --brand-dark: #6b82ee;
+  background: var(--bg); color: var(--ink);
+}
+.theme-dark .ribbon { background: var(--panel); border-bottom-color: var(--line); }
+.theme-dark .ribbon-tabs { border-bottom-color: var(--line); }
+.theme-dark .ribbon-body { background: linear-gradient(#2b2d31, #26282c); }
+.theme-dark .rgroup { border-right-color: var(--line); }
+.theme-dark .brand .logo { background: #34373d; color: #a9bcff; }
+.theme-dark .rtab { color: var(--muted); }
+.theme-dark .rtab:hover { background: #34373d; color: var(--ink); }
+.theme-dark .rtab.active { background: var(--bg); color: #cdd6ff; border-color: var(--line); }
+.theme-dark .rtab-context { color: #e0a05a; }
+.theme-dark .rtab-context.active { background: #3a3126; border-color: #5c4a30; color: #f0b46e; }
+
+.theme-dark .nav a { color: var(--muted); }
+.theme-dark .nav a:hover { background: #34373d; }
+.theme-dark .nav a.active { background: #2f3b57; color: #cdd6ff; }
+
+.theme-dark .ghost, .theme-dark .upload { background: #34373d; border-color: var(--line); color: var(--ink); }
+.theme-dark .ghost:hover:not(:disabled), .theme-dark .upload:hover { background: #3d4148; }
+.theme-dark .iconbtn { background: #34373d; border-color: var(--line); color: var(--ink); }
+.theme-dark .iconbtn:hover { background: #40454d; border-color: #55606f; }
+.theme-dark button.primary { background: var(--brand); color: #0b1020; }
+.theme-dark button.primary:hover:not(:disabled) { background: var(--brand-dark); }
+.theme-dark .del, .theme-dark .ghost.del { color: #ff9b9b; border-color: #6b3b3b; }
+.theme-dark .pageop { background: #34373d; border-color: var(--line); color: var(--ink); }
+.theme-dark .pageop:hover { background: #40454d; border-color: #55606f; }
+.theme-dark .pageop.del:hover { background: #4a2c2c; border-color: #7a4a4a; color: #ff9b9b; }
+
+.theme-dark input, .theme-dark select, .theme-dark textarea { background: #1f2125; color: var(--ink); border-color: var(--line); }
+.theme-dark input[type=color] { background: #1f2125; }
+.theme-dark .checkbox { color: var(--muted); }
+
+.theme-dark .editor-pages { background: var(--panel); border-color: var(--line); }
+.theme-dark .page-item { border-color: var(--line); }
+.theme-dark .page-item:hover { background: #34373d; }
+.theme-dark .page-item.active { background: #2f3b57; border-color: var(--brand); box-shadow: 0 0 0 1px var(--brand) inset; }
+.theme-dark .page-item.active .page-label { color: #cdd6ff; }
+
+.theme-dark .editor-stage { background: #202225; border-color: var(--line); }
+.theme-dark .stage-scroll { background: #141517; }   /* dark canvas around the white page */
+.theme-dark .ruler-corner { background: var(--panel); }
+
+.theme-dark .status.editor-status { color: var(--muted); }
+.theme-dark .rhint, .theme-dark .hint { color: var(--muted); }
+.theme-dark .editor-empty { color: var(--muted); }
+.theme-dark .editor-empty a { color: var(--brand); }
+/* Selection chrome stays visible on dark */
+.theme-dark .pf-piece:hover, .theme-dark .pf-node:hover { outline-color: #5a76e0; }
+
+/* Page-template picker modal */
+.pf-modal[hidden] { display: none; }
+.pf-modal { position: fixed; inset: 0; z-index: 1500; display: flex; align-items: center; justify-content: center; padding: 24px; }
+.pf-modal-backdrop { position: absolute; inset: 0; background: rgba(15, 18, 28, .5); }
+.pf-modal-box { position: relative; width: min(720px, 100%); max-height: 86vh; overflow: auto;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 20px 22px 24px; box-shadow: 0 18px 50px rgba(10, 14, 25, .35); }
+.pf-modal-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.pf-modal-head h2 { margin: 0; font-size: 19px; }
+.pf-modal-sub { color: var(--muted); font-size: 13px; margin: 6px 0 14px; }
+.pf-tpl-group { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); margin: 16px 0 8px; }
+.pf-tpl-count { text-transform: none; letter-spacing: 0; }
+.pf-tpl-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px; }
+.pf-tpl-card { position: relative; }
+.pf-tpl-pick { display: flex; flex-direction: column; gap: 3px; width: 100%; text-align: left; cursor: pointer;
+  background: #fff; border: 1px solid var(--line); border-radius: 10px; padding: 12px 13px; color: var(--ink); }
+.pf-tpl-pick:hover { border-color: var(--brand); background: #eef1fe; }
+.pf-tpl-name { font-weight: 600; font-size: 14px; }
+.pf-tpl-desc { font-size: 11.5px; color: var(--muted); }
+.pf-tpl-del { position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; line-height: 1; font-size: 11px;
+  border: 1px solid var(--line); background: #fff; border-radius: 6px; cursor: pointer; color: var(--muted); opacity: 0; transition: opacity .12s; }
+.pf-tpl-card:hover .pf-tpl-del { opacity: 1; }
+.pf-tpl-del:hover { background: #fdecec; border-color: #f5b5b5; color: #c0392b; }
+/* "Start from a template" call-to-action + gallery cards */
+.tpl-cta { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; cursor: pointer;
+  margin: 0 0 18px; padding: 13px 15px; border: 1px solid var(--nf-teal-100); border-radius: var(--radius-md);
+  background: var(--nf-gradient-brand-soft); color: var(--ink); }
+.tpl-cta:hover { border-color: var(--brand); box-shadow: var(--shadow-brand, 0 8px 22px rgba(15,181,166,.2)); }
+.tpl-cta-emoji { font-size: 24px; line-height: 1; }
+.tpl-cta-text { display: flex; flex-direction: column; gap: 1px; }
+.tpl-cta-text small { color: var(--muted); font-size: 12px; }
+.pf-tpl-emoji { font-size: 20px; }
+.pf-tpl-badge { align-self: flex-start; margin-top: 4px; font-size: 10.5px; font-weight: 600; letter-spacing: .2px;
+  padding: 2px 7px; border-radius: 999px; background: #eef1fe; color: var(--brand); }
+.theme-dark .tpl-cta { background: linear-gradient(120deg, #2b3350, #322b4d); border-color: #3f4a78; }
+.theme-dark .pf-tpl-badge { background: #2f3b57; color: #cdd6ff; }
+.theme-dark .pf-modal-box { background: #2b2d31; }
+.theme-dark .pf-tpl-pick { background: #1f2125; border-color: var(--line); color: var(--ink); }
+.theme-dark .pf-tpl-pick:hover { background: #2f3b57; border-color: var(--brand); }
+.theme-dark .pf-tpl-del { background: #34373d; border-color: var(--line); color: var(--muted); }
+
+/* Change Template — cards with visual thumbnail previews */
+.pf-modal-box.wide { width: min(940px, 100%); }
+.pf-tplchg-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 12px; }
+.pf-tplchg-card { position: relative; display: flex; flex-direction: column; gap: 6px; cursor: pointer;
+  background: #fff; border: 1px solid var(--line); border-radius: 10px; padding: 8px; color: var(--ink); text-align: left; }
+.pf-tplchg-card:hover { border-color: var(--brand); box-shadow: 0 4px 14px rgba(60, 80, 200, .14); }
+.pf-tplchg-thumb { position: relative; width: 100%; overflow: hidden; background: #fff;
+  border: 1px solid var(--line); border-radius: 5px; box-shadow: inset 0 0 0 1px rgba(0,0,0,.02); }
+.pf-tplchg-name { font-weight: 600; font-size: 13px; line-height: 1.15; }
+.pf-tplchg-desc { font-size: 11px; color: var(--muted); line-height: 1.2; }
+.pf-tplchg-del { position: absolute; top: 5px; right: 5px; width: 20px; height: 20px; line-height: 1; font-size: 11px;
+  border: 1px solid var(--line); background: #fff; border-radius: 6px; cursor: pointer; color: var(--muted); opacity: 0; transition: opacity .12s; z-index: 2; }
+.pf-tplchg-card:hover .pf-tplchg-del { opacity: 1; }
+.pf-tplchg-del:hover { background: #fdecec; border-color: #f5b5b5; color: #c0392b; }
+.theme-dark .pf-tplchg-card { background: #1f2125; border-color: var(--line); color: var(--ink); }
+.theme-dark .pf-tplchg-card:hover { border-color: var(--brand); }
+.theme-dark .pf-tplchg-thumb { background: #f4f5f8; border-color: #3a3d44; }
+.theme-dark .pf-tplchg-del { background: #34373d; border-color: var(--line); color: var(--muted); }
+
+/* Page Design → Size (read-only info) */
+.ro-field { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 130px; font-size: 12px; }
+.ro-field > span:first-child { color: var(--muted); }
+.ro-val { font-weight: 600; color: var(--ink); }
+.design-hint { font-size: 10.5px; color: var(--muted); font-style: italic; margin-top: 1px; }
+
+/* Format tab: dense Publisher layout (rows packed within each group) */
+.ribbon-panel[data-panel="format"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="format"] .rbig { min-width: 42px; max-width: 74px; padding: 2px 5px; font-size: 10px; min-height: 46px; }
+.ribbon-panel[data-panel="format"] .rbig .rbig-ico { font-size: 16px; }
+.ribbon-panel[data-panel="format"] .rmini { padding: 2px 6px; font-size: 11.5px; }
+.ribbon-panel[data-panel="format"] .rmini-col { gap: 2px; }
+.ribbon-panel[data-panel="format"] .iconbtn { padding: 3px 6px; }
+.font-2row { display: flex; flex-direction: column; gap: 3px; }
+.font-2row .frow { display: flex; gap: 3px; align-items: center; }
+.font-2row .mini { max-width: 104px; }
+.align-grid2 { display: grid; grid-template-columns: repeat(2, auto); gap: 2px; align-content: center; }
+.align-grid2 .js-line-spacing { grid-column: 1 / -1; width: 100%; }
+.rmini-col > .rdrop { display: flex; }
+.rmini-col > .rdrop > .rmini { width: 100%; }
+
+/* Text Box (Format) tab: WordArt gallery + effect fields */
+.wordart-gallery { display: flex; gap: 4px; }
+.wordart-swatch { width: 34px; height: 34px; font-size: 21px; line-height: 1; cursor: pointer;
+  border: 1px solid var(--line); border-radius: 6px; background: #fff; color: #222; }
+.wordart-swatch:hover { border-color: var(--brand); box-shadow: 0 2px 8px rgba(60,80,200,.15); }
+.theme-dark .wordart-swatch { background: #f4f5f8; }
+/* Text Fill / Text Outline colour palette dropdowns */
+.color-menu { width: 190px; padding: 6px; }
+.color-sec { font-size: 10.5px; text-transform: uppercase; letter-spacing: .4px; color: var(--muted); margin: 4px 2px 3px; }
+.color-row { display: grid; grid-template-columns: repeat(8, 1fr); gap: 3px; margin-bottom: 3px; }
+.color-sw { width: 100%; aspect-ratio: 1; padding: 0; border: 1px solid rgba(0,0,0,.25); border-radius: 3px; cursor: pointer; }
+.color-sw:hover { outline: 2px solid var(--brand); outline-offset: 1px; }
+.color-opt { display: block; width: 100%; text-align: left; padding: 6px 8px; font-size: 12.5px; }
+.color-row.wt-row { grid-template-columns: repeat(3, 1fr); }
+.wt-btn { padding: 4px 6px; font-size: 12px; border: 1px solid var(--line); border-radius: 5px; }
+/* Shape Format tab (2nd contextual): same dense rules as the Text Box tab */
+.ribbon-panel[data-panel="shapeformat"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="shapeformat"] .rbig { min-width: 42px; max-width: 74px; padding: 2px 5px; font-size: 10px; min-height: 46px; }
+.ribbon-panel[data-panel="shapeformat"] .rbig .rbig-ico { font-size: 16px; }
+.ribbon-panel[data-panel="shapeformat"] .rmini { padding: 2px 6px; font-size: 11.5px; }
+.ribbon-panel[data-panel="shapeformat"] .rmini-col { gap: 2px; }
+#sfShapeGallery, #sfStyleGallery { display: grid; grid-template-columns: repeat(3, auto); gap: 3px; align-content: center; }
+.sf-style-sw { width: 30px; height: 26px; border-radius: 4px; cursor: pointer; padding: 0; }
+.sf-style-sw:hover { outline: 2px solid var(--brand); outline-offset: 1px; }
+.size-fields.rmini-col .m { flex-direction: row; align-items: center; gap: 6px; }
+.size-fields .m > span { width: 42px; font-size: 11px; }
+.size-fields .m input { width: 64px; }
+/* Table Design / Table Layout tabs (dense, same rules as other Format tabs) */
+.ribbon-panel[data-panel="tabledesign"] .rgroup-body,
+.ribbon-panel[data-panel="tablelayout"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="tabledesign"] .rmini,
+.ribbon-panel[data-panel="tablelayout"] .rmini { padding: 2px 6px; font-size: 11.5px; }
+.ribbon-panel[data-panel="tabledesign"] .rmini-col,
+.ribbon-panel[data-panel="tablelayout"] .rmini-col { gap: 2px; }
+.ribbon-panel[data-panel="tablelayout"] .rbig { min-width: 42px; max-width: 74px; padding: 2px 5px; font-size: 10px; min-height: 46px; }
+.ribbon-panel[data-panel="tablelayout"] .rbig .rbig-ico { font-size: 16px; }
+.ribbon-panel[data-panel="tablelayout"] .m { flex-direction: row; align-items: center; gap: 4px; }
+.ribbon-panel[data-panel="tabledesign"] .m { flex-direction: row; align-items: center; gap: 4px; }
+.ribbon-panel[data-panel="tabledesign"] .m input { width: 52px; }
+.td-format-gallery { display: grid; grid-template-columns: repeat(3, auto); gap: 4px; align-content: center; }
+.td-fmt-sw { display: flex; flex-direction: column; width: 44px; height: 30px; padding: 2px; cursor: pointer; gap: 1px; background: #fff; }
+.td-fmt-sw:hover { outline: 2px solid var(--brand); outline-offset: 1px; }
+.td-fmt-h { display: block; height: 9px; border: 1px solid #333; }
+.td-fmt-b { display: block; flex: 1; border: 1px solid #333; border-top: none; }
+.tbl-headerchk { white-space: nowrap; }
+/* Selected table cells (for Merge / Split / Diagonals) */
+#stageInner td.cell-sel { outline: 2px solid var(--brand); outline-offset: -2px; background-image: linear-gradient(rgba(60,80,200,.14), rgba(60,80,200,.14)); }
+/* Picture Format tab (dense, same rules as other Format tabs) */
+.ribbon-panel[data-panel="pictureformat"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="pictureformat"] .rmini { padding: 2px 6px; font-size: 11.5px; }
+.ribbon-panel[data-panel="pictureformat"] .rmini-col { gap: 2px; }
+.ribbon-panel[data-panel="pictureformat"] .rbig { min-width: 42px; max-width: 74px; padding: 2px 5px; font-size: 10px; min-height: 46px; }
+.ribbon-panel[data-panel="pictureformat"] .rbig .rbig-ico { font-size: 16px; }
+.ribbon-panel[data-panel="pictureformat"] .m { flex-direction: row; align-items: center; gap: 4px; }
+.ribbon-panel[data-panel="pictureformat"] .m input { width: 60px; }
+.pic-adjust-menu { padding: 6px; }
+.pic-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
+.pic-sw { padding: 2px; cursor: pointer; }
+.pic-sw-img { display: block; width: 46px; height: 30px; border-radius: 3px; background: linear-gradient(135deg, #4dabf7 0%, #2b8a3e 55%, #f59f00 100%); }
+.pic-sw:hover .pic-sw-img { outline: 2px solid var(--brand); outline-offset: 1px; }
+#picStyleGallery { display: grid; grid-template-columns: repeat(3, auto); gap: 4px; align-content: center; }
+.pic-style-sw { padding: 3px; cursor: pointer; }
+.pic-style-img { display: block; width: 34px; height: 26px; background: linear-gradient(135deg, #74c0fc, #2b8a3e); }
+.pic-style-sw:hover { outline: 2px solid var(--brand); outline-offset: 1px; }
+/* QR Code contextual tab (dense, one-row Publisher layout) */
+.ribbon-panel[data-panel="qrformat"] .rgroup-body { flex-wrap: nowrap; align-items: center; }
+.ribbon-panel[data-panel="qrformat"] .rmini { padding: 2px 6px; font-size: 11.5px; }
+.ribbon-panel[data-panel="qrformat"] .rmini-col { gap: 2px; }
+.ribbon-panel[data-panel="qrformat"] .rbig { min-width: 42px; max-width: 74px; padding: 2px 5px; font-size: 10px; min-height: 46px; }
+.ribbon-panel[data-panel="qrformat"] .rbig .rbig-ico { font-size: 16px; }
+.ribbon-panel[data-panel="qrformat"] .m { flex-direction: row; align-items: center; gap: 4px; }
+.ribbon-panel[data-panel="qrformat"] .m input { width: 60px; }
+#qrStyleGallery { display: grid; grid-template-columns: repeat(3, auto); gap: 4px; align-content: center; }
+.qr-style-img { display: block; width: 26px; height: 26px; border: 1px solid rgba(0, 0, 0, .18); box-sizing: border-box; }
+.qr-style-img::after { content: "▚"; display: block; text-align: center; font-size: 18px; line-height: 24px; }
+#qrLinkMenu .qr-url input { width: 220px; }
+.rdrop-note { max-width: 240px; padding: 4px 8px 2px; font-size: 11px; color: var(--muted, #888); }
+/* Interactive crop overlay */
+.pf-crop-layer { pointer-events: none; }
+.pf-crop-rect { pointer-events: none; box-shadow: 0 0 0 9999px rgba(0, 0, 0, .5); outline: 1px solid #fff; }
+.pf-crop-h { position: absolute; width: 14px; height: 14px; background: #fff; border: 2px solid var(--brand); border-radius: 2px; pointer-events: auto; cursor: pointer; box-shadow: 0 1px 3px rgba(0, 0, 0, .4); }
+body.cropping .pf-node, body.cropping .pf-selbox { /* keep selection visuals out of the way while cropping */ }
+/* Active item in an applied dropdown (e.g. Typography → Stylistic Sets) */
+.rdrop-menu button.rdrop-on { font-weight: 600; }
+.rdrop-menu button.rdrop-on::before { content: "✓ "; color: var(--brand, #4c6ef5); }
+/* Linked text boxes (flow) */
+body.pf-linking #stageInner, body.pf-linking .pf-node { cursor: crosshair; }
+.pf-node.pf-overflow { outline: 2px dashed #e8590c; outline-offset: 1px; }
+.pf-node.pf-overflow::after { content: "⚠ overflow"; position: absolute; right: 0; bottom: -14px; font-size: 9px; color: #e8590c; background: rgba(255, 255, 255, .85); padding: 0 3px; border-radius: 2px; pointer-events: none; }
+.align-mini { display: inline-flex; gap: 2px; }
+.rmini-field { display: flex; align-items: center; gap: 6px; font-size: 12px; padding: 2px 4px; white-space: nowrap; }
+.rmini-field .mini-color { width: 30px; height: 24px; }
+
+/* Page Design → Fonts group */
+.font-actions { display: flex; gap: 5px; margin-top: 4px; }
+#customFontMenu { min-width: 190px; max-height: 260px; overflow: auto; padding: 4px; }
+.font-menu-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 4px; }
+.font-menu-row > button { width: auto; }
+.font-menu-row > button:first-child { min-width: 0; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.font-menu-del { width: 22px; color: var(--muted); }
+.font-menu-del:hover { color: #c0392b; }
+
+/* Publish modal */
+.pf-pub { width: min(640px, 100%); }
+.pf-pub-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.pf-pub .field.compact { margin: 0 0 10px; }
+.pf-pub textarea { width: 100%; font: inherit; padding: 7px 9px; border: 1px solid var(--line); border-radius: 8px; resize: vertical; }
+.pf-pub-checks { display: flex; flex-direction: column; gap: 5px; margin: 6px 0 4px; }
+.pf-pub-actions { display: flex; align-items: center; gap: 10px; margin: 4px 0 10px; }
+.pf-pub-footer { display: flex; align-items: center; gap: 12px; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line); }
+.pf-pub-status { font-size: 12.5px; color: var(--muted); }
+.pf-pub-status.busy { color: var(--brand); }
+.pf-pub-status.ok { color: var(--ok); }
+.pf-pub-status.err { color: #c0392b; }
+.pf-report { border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; margin-bottom: 12px; background: #fafbfd; font-size: 13px; }
+.rep-summary { font-size: 14px; margin-bottom: 8px; }
+.rep-summary b { font-variant-numeric: tabular-nums; }
+.rep-b { color: #c0392b; } .rep-w { color: #b4690e; } .rep-p { color: var(--ok); }
+.rep-subhead { font-weight: 600; margin: 12px 0 6px; }
+.rep-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+.rep-list li { padding-left: 10px; border-left: 3px solid var(--line); }
+.rep-list li.blocker { border-left-color: #c0392b; }
+.rep-list li.warning { border-left-color: #e0a05a; }
+.rep-ok { color: var(--ok); }
+.rep-note { color: var(--muted); }
+.rep-note.err { color: #c0392b; }
+.rep-dim { color: var(--muted); }
+.pf-cover-status { font-size: 13px; color: var(--muted); margin-bottom: 8px; }
+.pf-cover-status.ok { color: var(--ok); }
+.pf-cover-status.busy { color: var(--brand); }
+.theme-dark .pf-pub textarea, .theme-dark .pf-pub input, .theme-dark .pf-pub select { background: #1f2125; color: var(--ink); border-color: var(--line); }
+.theme-dark .pf-report { background: #26282c; border-color: var(--line); }
+
+/* Page Editor */
+.editor-actions { display: flex; gap: 6px; align-items: center; }
+.zoombar { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--line); border-radius: 9px; padding: 2px 4px; }
+.zoom-label { font-size: 12px; color: var(--muted); min-width: 38px; text-align: center; }
+.iconbtn { border: 1px solid var(--line); background: #fff; border-radius: 8px; padding: 5px 9px; font-size: 15px; line-height: 1; cursor: pointer; color: var(--ink); }
+.iconbtn:hover { background: #eef1fe; border-color: #c9d4ff; }
+.editor-status { max-width: 1320px; margin: 8px auto 0; padding: 0 20px; }
+.editor-layout { display: grid; grid-template-columns: 180px 1fr 290px; gap: 14px; padding: 10px 16px; max-width: 1320px; margin: 0 auto; align-items: start; }
+.editor-pages, .editor-tools { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 14px; }
+.editor-tools { max-height: 86vh; overflow: auto; }
+.editor-pages h2, .editor-tools h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); margin: 14px 0 8px; }
+.editor-pages h2:first-child, .editor-tools h2:first-child { margin-top: 0; }
+.page-list { list-style: none; margin: 0; padding: 0; max-height: 76vh; overflow: auto; }
+.page-item { display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 8px; border: 1px solid var(--line); border-radius: 10px; margin-bottom: 8px; cursor: pointer; }
+.page-item:hover { background: #f1f3f9; }
+.page-item.active { background: #eef1fe; border-color: var(--brand); box-shadow: 0 0 0 1px var(--brand) inset; }
+/* Page thumbnail (scaled, non-interactive snapshot) */
+.thumb { position: relative; overflow: hidden; background: #fff; border: 1px solid var(--line); border-radius: 3px; box-shadow: 0 1px 3px rgba(20,26,45,.14); }
+.page-item.active .thumb { border-color: var(--brand); }
+.thumb-canvas { position: absolute; top: 0; left: 0; transform-origin: top left; background: #fff; pointer-events: none; }
+.thumb-canvas * { pointer-events: none !important; cursor: default !important; }
+.page-thumb { cursor: pointer; }
+.page-bar { display: flex; align-items: center; gap: 4px; width: 100%; }
+.page-label { flex: 1; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.page-item.active .page-label { color: var(--brand); font-weight: 600; }
+.page-ops { display: inline-flex; gap: 2px; opacity: .35; transition: opacity .12s; }
+.page-item:hover .page-ops, .page-item.active .page-ops { opacity: 1; }
+.pageop { border: 1px solid var(--line); background: #fff; border-radius: 5px; width: 20px; height: 20px; line-height: 1; font-size: 11px; padding: 0; cursor: pointer; color: var(--ink); }
+.pageop:hover { background: #eef1fe; border-color: #c9d4ff; }
+.pageop.del:hover { background: #fdecec; border-color: #f5b5b5; color: #c0392b; }
+.page-add { margin-top: 8px; }
+.page-add button { width: 100%; }
+
+/* Stage with rulers */
+.editor-stage { display: grid; grid-template-columns: 22px 1fr; grid-template-rows: 22px 1fr; background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 6px; }
+.ruler-corner { grid-area: 1 / 1; background: #eef0f6; border-radius: 4px; }
+.ruler { background: #fbfbfd; }
+.ruler-top { grid-area: 1 / 2; }
+.ruler-left { grid-area: 2 / 1; }
+.stage-scroll { grid-area: 2 / 2; overflow: auto; max-height: 82vh; display: flex; justify-content: center; align-items: flex-start; padding: 8px; }
+.stage-outer { position: relative; background: #fff; box-shadow: 0 2px 14px rgba(0,0,0,.12); overflow: hidden; flex: 0 0 auto; }
+.stage-inner { position: relative; background: #fff; transform-origin: top left; }
+/* View → Show toggles */
+.editor-stage.no-rulers { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+.editor-stage.no-rulers .ruler-corner, .editor-stage.no-rulers .ruler { display: none; }
+.editor-stage.no-rulers .stage-scroll { grid-area: 1 / 1; }
+.ribbon-layout.no-nav { grid-template-columns: 1fr !important; }
+.ribbon-layout.no-nav .editor-pages { display: none; }
+.stage-inner.show-bounds { outline: 1.5px dashed #2f9e6a; outline-offset: 0; }
+
+/* Master pages */
+.master-banner { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 8px 14px; margin: 8px 16px 0; border-radius: 10px; background: #eef1fe; border: 1px solid var(--brand); color: #33407a; font-size: 13px; }
+.master-banner[hidden] { display: none; }
+
+/* Ribbon split-button dropdowns (Page ▾, …) */
+.rdrop { position: relative; display: inline-flex; }
+.rdrop-btn { display: inline-flex; align-items: center; }
+.rdrop-caret { font-size: 10px; margin-left: 1px; }
+/* Fixed so the menu floats above the ribbon instead of being clipped by its
+   overflow (which would add an ugly scrollbar). Position is set in JS on open. */
+.rdrop-menu { position: fixed; z-index: 3000; min-width: 200px;
+  background: var(--panel, #fff); border: 1px solid var(--line); border-radius: 10px; box-shadow: 0 8px 24px rgba(20, 26, 45, .20); padding: 5px; }
+.rdrop-menu[hidden] { display: none; }
+.rdrop-menu button { display: block; width: 100%; text-align: left; background: none; border: none;
+  padding: 8px 12px; border-radius: 7px; font-size: 13px; color: var(--ink); cursor: pointer; white-space: nowrap; }
+.rdrop-menu button:hover { background: #eef1fe; color: var(--brand); }
+.theme-dark .rdrop-menu { background: #34373d; }
+.theme-dark .rdrop-menu button:hover { background: #2f3b57; color: #cdd6ff; }
+
+/* Home → Objects group: Text / Pictures / Table / Shapes */
+.objects-body { gap: 2px; flex-wrap: nowrap; }
+.objbtn { display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 2px; min-width: 52px; padding: 5px 8px; font-size: 11px; line-height: 1.1; }
+.objbtn .objbtn-ico { font-size: 17px; line-height: 1; }
+.objbtn.rdrop-btn { flex-direction: column; }
+.objbtn .rdrop-caret { margin: 0; }
+
+/* Table grid-picker */
+.tablepick-menu { min-width: 0; padding: 8px; }
+.tablepick-grid { display: grid; gap: 2px; }
+.tablepick-cell { width: 16px; height: 16px; border: 1px solid var(--line); border-radius: 2px; background: #fff; cursor: pointer; }
+.tablepick-cell.on { background: #4263eb; border-color: #2f4bd6; }
+.tablepick-label { text-align: center; font-size: 12px; color: var(--ink); margin-top: 7px; }
+.tablepick-more { display: block; width: 100%; text-align: center !important; margin-top: 6px;
+  border-top: 1px solid var(--line) !important; border-radius: 0 !important; padding-top: 8px !important; }
+.theme-dark .tablepick-cell { background: #2a2d33; border-color: #4a4f57; }
+.theme-dark .tablepick-cell.on { background: #4263eb; border-color: #6d86f0; }
+
+/* Shape gallery */
+.shapegal-menu { min-width: 0; max-width: 220px; max-height: 60vh; overflow-y: auto; padding: 6px 8px; }
+.shapegal-cat { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  color: var(--muted, #8a90a2); margin: 8px 2px 3px; }
+.shapegal-cat:first-child { margin-top: 2px; }
+.shapegal-grid { display: grid; grid-template-columns: repeat(6, 30px); gap: 3px; }
+.shapegal-grid .shape-btn { display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 28px; padding: 2px; }
+.shapegal-grid .shape-btn svg { max-width: 24px; max-height: 20px; }
+.theme-dark .master-banner { background: #2f3b57; border-color: var(--brand); color: #cdd6ff; }
+.pf-master-ov { pointer-events: none; }                 /* master overlay is non-interactive on normal pages */
+body:not(.master-editing) .pf-master-ov { opacity: .82; }
+body.master-editing .editor-stage { outline: 2px solid var(--brand); outline-offset: -1px; }
+
+/* Two-page spread */
+.spread-facing { cursor: pointer; opacity: .92; }
+.spread-facing:hover { opacity: 1; outline: 2px solid var(--brand); outline-offset: -1px; }
+.spread-gutter { pointer-events: none; background: linear-gradient(90deg, rgba(0,0,0,.12), rgba(0,0,0,0) 45%, rgba(0,0,0,0) 55%, rgba(0,0,0,.12)); }
+.pf-grid-overlay { position: absolute; inset: 0; pointer-events: none; z-index: 0;
+  background: repeating-linear-gradient(0deg,#eef0f6 0 1px,transparent 1px 24px),repeating-linear-gradient(90deg,#eef0f6 0 1px,transparent 1px 24px); }
+.pf-flow { position: relative; z-index: 1; width: 100%; }
+.pf-piece { position: relative; transform-origin: top left; cursor: move; }
+.pf-piece:hover { outline: 1px dashed #c9d4ff; }
+.pf-node { position: absolute; top: 0; left: 0; transform-origin: top left; cursor: move; z-index: 2; }
+.pf-node.pf-behind { z-index: 0; }   /* sent behind the puzzle/title/word-list */
+.pf-node:hover { outline: 1px dashed #c9d4ff; }
+.pf-textbox { min-width: 20px; }
+.pf-sel-layer { position: absolute; inset: 0; pointer-events: none; z-index: 997; }
+.pf-selbox { position: absolute; top: 0; left: 0; transform-origin: top left; outline: 1.5px solid var(--brand); }
+/* 8-point resize handles */
+.pf-h { position: absolute; width: 10px; height: 10px; background: #fff; border: 1.5px solid var(--brand); border-radius: 2px; pointer-events: auto; }
+.pf-h[data-d=nw] { left: -6px; top: -6px; cursor: nwse-resize; }
+.pf-h[data-d=n]  { left: calc(50% - 5px); top: -6px; cursor: ns-resize; }
+.pf-h[data-d=ne] { right: -6px; top: -6px; cursor: nesw-resize; }
+.pf-h[data-d=e]  { right: -6px; top: calc(50% - 5px); cursor: ew-resize; }
+.pf-h[data-d=se] { right: -6px; bottom: -6px; cursor: nwse-resize; }
+.pf-h[data-d=s]  { left: calc(50% - 5px); bottom: -6px; cursor: ns-resize; }
+.pf-h[data-d=sw] { left: -6px; bottom: -6px; cursor: nesw-resize; }
+.pf-h[data-d=w]  { left: -6px; top: calc(50% - 5px); cursor: ew-resize; }
+/* rotate handle above the selection */
+.pf-rot-stem { position: absolute; left: 50%; top: -22px; width: 1.5px; height: 22px; background: var(--brand); pointer-events: none; }
+.pf-rot { position: absolute; left: calc(50% - 7px); top: -34px; width: 14px; height: 14px; border-radius: 50%;
+  background: #fff; border: 1.5px solid var(--brand); cursor: grab; pointer-events: auto; }
+.pf-rot:active { cursor: grabbing; }
+/* marquee (rubber-band) selection */
+.pf-marquee { position: absolute; border: 1px dashed var(--brand); background: rgba(59,91,219,.08); z-index: 996; pointer-events: none; }
+/* right-click context menu */
+.pf-ctx { position: fixed; z-index: 2000; min-width: 170px; background: var(--panel); border: 1px solid var(--line);
+  border-radius: 10px; box-shadow: 0 8px 28px rgba(10,14,25,.22); padding: 5px; display: flex; flex-direction: column; }
+.pf-ctx button { border: none; background: transparent; text-align: left; padding: 7px 12px; font-size: 13px; color: var(--ink); border-radius: 7px; cursor: pointer; }
+.pf-ctx button:hover { background: #eef1fe; color: var(--brand); }
+.pf-ctx-sep { height: 1px; background: var(--line); margin: 4px 6px; }
+.theme-dark .pf-ctx { background: #33363c; border-color: var(--line); }
+.theme-dark .pf-ctx button:hover { background: #2f3b57; color: #cdd6ff; }
+/* B / I / U toggle buttons */
+.btnrow { display: inline-flex; gap: 3px; }
+.tstyle { width: 30px; text-align: center; }
+.tstyle.on { background: #eef1fe; border-color: var(--brand); color: var(--brand); }
+.theme-dark .tstyle.on { background: #2f3b57; border-color: var(--brand); color: #cdd6ff; }
+.pf-handle { position: absolute; right: -7px; bottom: -7px; width: 14px; height: 14px; border-radius: 50%;
+  background: #fff; border: 2px solid var(--brand); pointer-events: auto; cursor: nwse-resize; }
+.pf-guide { position: absolute; background: #ff2d9b; z-index: 998; pointer-events: none; }
+.pf-guide-v { top: 0; width: 1px; height: 100%; }
+.pf-guide-h { left: 0; height: 1px; width: 100%; }
+
+/* Tools panel */
+.measure { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 10px; }
+.measure .m { display: flex; flex-direction: column; gap: 2px; }
+.measure .m > span { font-size: 11px; color: var(--muted); }
+.measure .m input { padding: 6px 7px; font-size: 13px; }
+.align-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 10px; }
+.editor-tools .actions { margin-bottom: 8px; flex-wrap: wrap; gap: 6px; }
+.editor-tools .actions .ghost { padding: 6px 9px; font-size: 12px; }
+.editor-tools .del { color: #c92a2a; border-color: #f2c2c2; }
+.editor-empty { text-align: center; color: var(--muted); padding: 60px 20px; font-size: 14px; }
+.editor-empty[hidden] { display: none; }
+
+/* Publish checklist */
+.checklist { margin: 10px 0; border: 1px solid var(--line); border-radius: 11px; padding: 12px; }
+.checklist.hidden { display: none; }
+.chk-busy { font-size: 13px; color: var(--muted); margin: 0; }
+.chk-summary { font-size: 13px; margin: 0 0 8px; padding-bottom: 8px; border-bottom: 1px solid var(--line); }
+.chk-row { display: flex; gap: 8px; align-items: baseline; padding: 4px 0; font-size: 13px; }
+.chk-ic { flex: 0 0 auto; }
+.chk-label { color: var(--ink); }
+.chk-row.chk-pass .chk-label { color: var(--muted); }
+.chk-msg { color: #9a3412; }
+
+/* Royalty estimate */
+.royalty { margin-top: 8px; border: 1px solid var(--line); border-radius: 9px; padding: 8px 10px; }
+.royalty.hidden { display: none; }
+.roy-row { display: flex; justify-content: space-between; gap: 12px; font-size: 13px; padding: 3px 0; }
+.roy-row span:first-child { color: var(--muted); }
+.roy-good { color: var(--ok); }
+.roy-bad { color: #c92a2a; }
+.checkbox-label { display: block; font-size: 12px; color: var(--muted); margin: 8px 0 4px; }
+
+/* Manage themes list */
+.manage-list { margin-top: 8px; }
+.manage-cat { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); margin: 12px 0 4px; }
+.manage-row { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 6px 8px; border: 1px solid var(--line); border-radius: 9px; margin-bottom: 6px; }
+.manage-name { font-size: 14px; }
+.manage-actions { display: flex; gap: 6px; }
+.manage-actions .iconbtn { border: 1px solid var(--line); background: var(--panel); color: var(--ink); border-radius: 7px;
+  padding: 4px 10px; font-size: 12px; cursor: pointer; color: var(--ink); }
+.manage-actions .iconbtn:hover { background: var(--hover-bg); }
+.manage-actions .iconbtn.del { color: #c92a2a; border-color: #f2c2c2; }
+
+/* ===== Save-state indicator + My Books library ===== */
+.save-state { font-size: 12px; color: var(--muted); margin-right: 6px; white-space: nowrap; }
+.save-state.ok { color: #2b8a3e; }
+.save-state.busy { color: var(--brand); }
+.save-state.err { color: #c92a2a; }
+
+.lib-main { max-width: 1100px; margin: 0 auto; padding: 22px 20px 60px; }
+.lib-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.lib-head h2 { margin: 0; }
+.lib-actions { display: flex; gap: 8px; align-items: center; }
+.lib-btn { padding: 8px 14px; border-radius: 8px; font-size: 14px; text-decoration: none; display: inline-flex; align-items: center; cursor: pointer; }
+a.primary.lib-btn { background: var(--brand); color: #fff; border: 1px solid var(--brand); }
+.lib-note { color: var(--muted); font-size: 13px; margin: 6px 0 18px; }
+.lib-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 14px; }
+.lib-card { display: flex; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--panel, #fff); box-shadow: 0 1px 4px rgba(20,26,45,.07); }
+.lib-spine { width: 10px; background: var(--tint, #4a6cff); flex: 0 0 auto; }
+.lib-body { padding: 14px 16px; flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.lib-body h3 { margin: 0; font-size: 16px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lib-sub { margin: 0; color: var(--muted); font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lib-meta { margin: 2px 0 10px; color: var(--muted); font-size: 12px; }
+.lib-card-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: auto; }
+.lib-card-actions button { padding: 5px 10px; font-size: 12px; border-radius: 7px; border: 1px solid var(--line); background: var(--panel); color: var(--ink); cursor: pointer; }
+.lib-card-actions button.primary { background: var(--brand); color: #fff; border-color: var(--brand); }
+.lib-card-actions button.del { color: #c92a2a; border-color: #f2c2c2; }
+.lib-empty { text-align: center; color: var(--muted); padding: 60px 20px; }
+
+/* Team library section */
+.lib-teamhead { margin-top: 34px; border-top: 1px solid var(--line); padding-top: 18px; }
+.lib-team-status { font-size: 13px; color: var(--muted); font-weight: 400; }
+
+/* ===== Touch: drag objects/handles instead of scrolling/zooming the page ===== */
+.pf-node, .pf-piece, .pf-handle { touch-action: none; }
+.pf-handle { width: 16px; height: 16px; right: -8px; bottom: -8px; }
+
+/* ===== Phone / small-screen layout ===== */
+@media (max-width: 720px) {
+  /* Shared chrome */
+  .topbar { padding: 10px 12px; gap: 8px; }
+  .brand .tagline { display: none; }
+  .brand h1 { font-size: 17px; }
+  .nav { gap: 4px; overflow-x: auto; -webkit-overflow-scrolling: touch; width: 100%; flex-wrap: nowrap; }
+  .nav a { flex: 0 0 auto; padding: 7px 11px; font-size: 13px; }
+
+  /* Form-style pages (Book Builder, Puzzle Maker, Themes, Cover, Image Tools) */
+  .layout { grid-template-columns: 1fr; padding: 12px; gap: 14px; }
+  .row { grid-template-columns: 1fr; }
+  .preview { position: static; }
+  .preview-frame, .preview-frame iframe { height: 62vh; min-height: 0; }
+
+  /* My Books */
+  .lib-main { padding: 14px 12px 48px; }
+  .lib-grid { grid-template-columns: 1fr; }
+  .lib-head { align-items: flex-start; }
+
+  /* ---- Page Editor ---- */
+  .ribbon { position: static; }   /* tall ribbon scrolls away so the canvas gets the screen */
+  .ribbon-title { flex-wrap: wrap; gap: 8px; padding: 6px 10px; }
+  .ribbon-title .brand h1 { font-size: 15px; }
+  .ribbon-title .brand .logo { width: 32px; height: 32px; font-size: 18px; }
+  .ribbon-title .nav { order: 4; }
+  .ribbon-qa { margin-left: 0; width: 100%; order: 5; flex-wrap: wrap; gap: 6px; }
+  .ribbon-qa .ghost, .ribbon-qa .primary, .ribbon-qa .upload { padding: 7px 10px; font-size: 13px; }
+  .ribbon-tabs { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; padding: 0 8px; }
+  .rtab { flex: 0 0 auto; padding: 8px 12px; }
+  .ribbon-body { min-height: 0; padding: 8px; overflow-x: auto; }
+  .rgroup { padding: 2px 8px; }
+
+  /* Single column: canvas on top, pages as a horizontal filmstrip below */
+  .ribbon-layout { grid-template-columns: 1fr !important; padding: 8px; gap: 8px; }
+  .editor-stage { order: 1; grid-template-columns: 1fr; grid-template-rows: 1fr; min-height: 0 !important; padding: 4px; }
+  .editor-stage .ruler, .editor-stage .ruler-corner { display: none; }
+  .stage-scroll { grid-area: 1 / 1; max-height: 58vh; }
+  .editor-pages { order: 2; padding: 8px; }
+  .editor-pages h2, .editor-pages .hint { display: none; }
+  .page-list { display: flex; flex-direction: row; gap: 8px; max-height: none; overflow-x: auto; overflow-y: hidden; padding-bottom: 6px; }
+  .page-item { flex: 0 0 auto; width: 88px; margin-bottom: 0; }
+  .page-item .page-ops { display: none; }        /* reorder/delete live in the Page Design tab */
+  .page-item .page-label { font-size: 10px; }
+  .page-add { display: flex; gap: 6px; margin-top: 8px; }
+  .editor-status { padding: 0 12px; }
+
+  /* Master banner + modals fit the screen */
+  .master-banner { flex-wrap: wrap; gap: 6px; margin: 6px 10px 0; }
+  .pf-modal { padding: 10px; }
+  .pf-modal-box { width: 96vw; max-height: 90vh; padding: 16px; }
+  .pf-help-body { grid-template-columns: 1fr; }
+  .pf-help-cats { flex-direction: row; overflow-x: auto; gap: 4px; }
+  .pf-pub-grid, .pf-team-add, .wc-grid { grid-template-columns: 1fr; }
+  .pf-team-row { flex-direction: column; align-items: flex-start; }
+}
+
+/* --- Identity chip + sign-in modal (shared, all pages) --- */
+#pf-identity { position: relative; display: inline-flex; align-items: center; margin-left: 8px; z-index: 900; }
+#pf-identity.floating { position: fixed; top: 10px; right: 12px; margin: 0; }
+.pf-id-chip .pf-id-btn { display: flex; align-items: center; gap: 8px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 999px; padding: 4px 10px 4px 4px; cursor: pointer;
+  font: inherit; color: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+.pf-id-chip.signed-out .pf-id-btn { padding: 6px 14px; color: var(--brand); font-weight: 600; }
+.pf-id-av { width: 26px; height: 26px; border-radius: 50%; color: #fff; font-size: 11px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+.pf-id-name { font-weight: 600; max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pf-id-role { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .3px; }
+.pf-id-caret { color: var(--muted); font-size: 11px; }
+.pf-id-menu { display: none; position: absolute; top: 100%; right: 0; margin-top: 6px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 10px; box-shadow: var(--shadow-md, 0 8px 24px rgba(0,0,0,.14)); min-width: 180px; overflow: hidden; z-index: 1001; }
+.pf-id-chip.open .pf-id-menu { display: block; }
+.pf-id-menu a, .pf-id-menu button { display: block; width: 100%; text-align: left; padding: 10px 14px;
+  background: none; border: none; font: inherit; color: var(--ink); cursor: pointer; text-decoration: none; }
+.pf-id-menu a:hover, .pf-id-menu button:hover { background: var(--bg); }
+
+.pf-id-overlay { position: fixed; inset: 0; background: rgba(20,24,34,.45); z-index: 1000;
+  display: flex; align-items: center; justify-content: center; padding: 20px; }
+.pf-id-modal { background: var(--panel); color: var(--ink); border-radius: 14px; padding: 22px;
+  width: 100%; max-width: 420px; box-shadow: 0 18px 50px rgba(0,0,0,.28); max-height: 90vh; overflow-y: auto; }
+.pf-id-modal h2 { margin: 0 0 6px; font-size: 20px; }
+.pf-id-sub { margin: 0 0 14px; color: var(--muted); font-size: 13px; line-height: 1.5; }
+.pf-id-field { display: block; margin: 0 0 12px; }
+.pf-id-field > span { display: block; font-size: 12px; font-weight: 600; color: var(--muted); margin-bottom: 4px; }
+.pf-id-field input, .pf-id-field select { width: 100%; padding: 9px 11px; border: 1px solid var(--line);
+  border-radius: 8px; font: inherit; background: var(--bg); color: var(--ink); }
+.pf-id-picklist { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+.pf-id-pick { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border: 1px solid var(--line);
+  border-radius: 10px; background: var(--bg); cursor: pointer; font: inherit; color: var(--ink); text-align: left; }
+.pf-id-pick:hover { border-color: var(--brand); }
+.pf-id-pick-main { display: flex; flex-direction: column; }
+.pf-id-pick-main small { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .3px; }
+.pf-id-pinrow { display: flex; gap: 8px; align-items: flex-end; margin-bottom: 10px; }
+.pf-id-pinrow .pf-id-field { flex: 1; margin: 0; }
+.pf-id-err { color: #c92a2a; font-size: 13px; min-height: 18px; margin: 4px 0 0; }
+.pf-id-modal-foot { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; flex-wrap: wrap; }
+.pf-id-modal-foot .primary { background: var(--brand); color: #fff; border: none; padding: 9px 16px; border-radius: 8px; font: inherit; font-weight: 600; cursor: pointer; }
+.pf-id-modal-foot .ghost { background: none; border: 1px solid var(--line); padding: 9px 14px; border-radius: 8px; font: inherit; color: var(--ink); cursor: pointer; }
+.pf-id-modal-foot .primary:hover { background: var(--brand-dark); }
+
+/* --- Collapsible tool groups + tooltips (progressive disclosure) --- */
+.pf-group { border: 1px solid var(--line); border-radius: 11px; margin: 0 0 10px; background: var(--panel); }
+.pf-group > summary { list-style: none; cursor: pointer; padding: 12px 14px; display: flex;
+  align-items: center; gap: 8px; font-weight: 600; font-size: 14px; color: var(--ink); user-select: none; }
+.pf-group > summary::-webkit-details-marker { display: none; }
+.pf-group > summary::after { content: "▾"; margin-left: auto; color: var(--muted); font-size: 12px; transition: transform .15s ease; }
+.pf-group[open] > summary::after { transform: rotate(180deg); }
+.pf-group > summary:hover { background: var(--bg); border-radius: 11px; }
+.pf-group[open] > summary { border-bottom: 1px solid var(--line); border-radius: 11px 11px 0 0; }
+.pf-group .sub { font-weight: 400; font-size: 12px; color: var(--muted); }
+.pf-group-body { padding: 14px; }
+.pf-group-body > *:first-child { margin-top: 0; }
+
+/* Small info tooltip badge — put an explanation in title="" */
+.pf-info { display: inline-flex; align-items: center; justify-content: center; width: 15px; height: 15px;
+  border-radius: 50%; background: var(--line); color: var(--muted); font-size: 10px; font-weight: 700;
+  cursor: help; margin-left: 5px; vertical-align: middle; font-style: normal; }
+.pf-info:hover { background: var(--brand); color: #fff; }
+.theme-dark .pf-info { background: #3a3d44; }
+
+/* Tighter checkbox stacks inside groups */
+.pf-checks { display: flex; flex-direction: column; gap: 9px; }
+.pf-checks .checkbox { color: var(--ink); }
+
+/* --- Editor rulers: measurement numbers + draggable guides --- */
+.ruler { position: relative; overflow: hidden; }
+.ruler-top { cursor: row-resize; }   /* drag DOWN to place a horizontal guide */
+.ruler-left { cursor: col-resize; }  /* drag RIGHT to place a vertical guide */
+.ruler-marks { position: absolute; inset: 0; pointer-events: none; }
+.ruler-marks span { position: absolute; font-size: 9px; line-height: 1; color: #7a8194; font-variant-numeric: tabular-nums; }
+.ruler-top .ruler-marks span { top: 3px; transform: translateX(2px); }
+.ruler-left .ruler-marks span { left: 2px; }
+.theme-dark .ruler-marks span { color: #aeb6c6; }
+
+.pf-user-guide { position: absolute; z-index: 996; }
+.pf-user-guide.v { top: 0; height: 100%; width: 1px; background: #0aa2c0; cursor: col-resize; }
+.pf-user-guide.h { left: 0; width: 100%; height: 1px; background: #0aa2c0; cursor: row-resize; }
+.pf-user-guide::before { content: ""; position: absolute; }        /* wider grab zone */
+.pf-user-guide.v::before { top: 0; bottom: 0; left: -3px; right: -3px; }
+.pf-user-guide.h::before { left: 0; right: 0; top: -3px; bottom: -3px; }
+.pf-user-guide.dragging { opacity: .85; }

--- a/publisher/server.js
+++ b/publisher/server.js
@@ -1,0 +1,714 @@
+/**
+ * PuzzleForge Publisher — standalone MS-Publisher-style page editor.
+ *
+ * A thin Express server over the PuzzleForge engine, trimmed to only what the
+ * Page Editor itself calls: assemble/open a book, insert/reroll a puzzle page,
+ * export a PDF, pre-flight checklist, AI proofread + thesaurus, and the KDP
+ * package export. Every other PuzzleForge Web feature (Puzzle Maker, Book
+ * Builder, Worksheets, Themes, Image Tools, Cover Builder, AI Art, the team
+ * workspace) is intentionally absent — this app is the page editor only.
+ */
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const crypto = require('crypto');
+const express = require('express');
+const archiver = require('archiver');
+const Anthropic = require('@anthropic-ai/sdk');
+
+// Import the engine as a package (file:.. dependency) with a relative fallback
+// so the app runs whether or not it has been `npm install`ed.
+let pf;
+try {
+  pf = require('puzzleforge-engine');
+} catch (_) {
+  pf = require('..');
+}
+
+const app = express();
+app.use(express.json({ limit: '16mb' }));
+app.use(express.static(path.join(__dirname, 'public')));
+// Browsers auto-request /favicon.ico; serve the SVG brand mark so it doesn't 404.
+app.get('/favicon.ico', (req, res) => {
+  res.type('image/svg+xml').sendFile(path.join(__dirname, 'public', 'favicon.svg'));
+});
+// The engine's element renderer is shared with the editor so on-screen objects
+// and exported PDF pixels match exactly.
+app.get('/element-html.js', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'engine', 'element-html.js'));
+});
+// The engine's border renderer, shared with the editor so the live page border
+// matches the printed one exactly.
+app.get('/decor.js', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'engine', 'decor.js'));
+});
+// QR encoder (qrcode-generator, MIT) served so the editor can build a QR's
+// module matrix client-side — the same library the engine uses, so an editor
+// QR matches a server-generated one.
+app.get('/qrcode-generator.js', (req, res) => {
+  res.sendFile(require.resolve('qrcode-generator'));
+});
+
+const WORD_TYPES = new Set(['wordsearch', 'wordscramble', 'crossword', 'krisskross']);
+const RECIPE_VERSION = 1;
+
+// --- API ---
+
+app.get('/api/meta', (req, res) => {
+  const themes = pf.listThemesDetailed();
+  res.json({
+    types: pf.listTypes(),
+    wordTypes: [...WORD_TYPES],
+    themes,
+    trimSizes: pf.listTrimSizes(),
+    borderStyles: pf.borderStyles,
+    // Audience-specific difficulty labels (internal levels 1–4).
+    difficulty: {
+      levels: pf.difficultyLevels,
+      kids: pf.difficultyOptions('kids'),
+      adult: pf.difficultyOptions('adult'),
+    },
+    recipeVersion: RECIPE_VERSION,
+  });
+});
+
+// --- Book builder (assembly helpers the editor depends on) ---
+
+const bookCache = new Map();
+function cacheBook(book) {
+  const id = crypto.randomUUID();
+  bookCache.set(id, book);
+  if (bookCache.size > 50) bookCache.delete(bookCache.keys().next().value);
+  return id;
+}
+
+app.post('/api/book/pdf', async (req, res) => {
+  const body = req.body || {};
+  try {
+    let book = body.bookId && bookCache.get(body.bookId);
+    if (!book) book = pf.assembleBook(body.config || {});
+    if (body.master !== undefined) book.master = body.master;
+    book.customFonts = sanitizeCustomFonts(body.fonts);
+    // The Page Editor sends live per-page state (decorations + per-page border)
+    // to apply onto the cached (possibly rerolled) book before rendering. A
+    // pagePlan additionally reorders / inserts blanks / deletes / duplicates.
+    let leaves;
+    if (Array.isArray(body.pagePlan)) { const r = pagePlanRender(book, body.pagePlan); book = r.view; leaves = r.leaves; }
+    else applyPageState(book, body.pageState);
+    const outPath = path.join(os.tmpdir(), `pf-book-${crypto.randomUUID()}.pdf`);
+    await pf.exportBookPdf(book, { outPath, leaves });
+    const pdf = fs.readFileSync(outPath);
+    fs.unlink(outPath, () => {});
+    const base = (book.title || 'book').replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${base}.pdf"`);
+    res.send(pdf);
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
+// --- Page Editor ---
+
+// Apply an editor pageState array (by content-page index) onto a cached book.
+function applyPageState(book, pageState) {
+  if (!Array.isArray(pageState) || !book || !Array.isArray(book.pages)) return;
+  book.pages.forEach((pg, i) => {
+    if (pageState[i] && typeof pageState[i] === 'object') pg.state = pageState[i];
+  });
+}
+
+// Turn an editor "page plan" into an engine leaf list + a matching book VIEW.
+// The plan is the final order of ALL pages (title, front matter, puzzles,
+// answer key, back matter) with inserted blanks, deletions, duplicates, and
+// per-page edit state. Each entry names a role:
+//   { role:'content', src, state }   reuse cached content page `src`
+//   { role:'blank', state }          fresh blank page
+//   { role:'title'|'answerkey', state }
+//   { role:'frontmatter'|'backmatter', matterKind, state }
+// Returns { view, leaves }: `leaves` drives page order/rendering; `view` is a
+// shallow book copy whose `.pages` are the plan's content pages (so the answer
+// key + page counts reflect the arrangement). The cached book is never mutated.
+// Human label for a non-content (title / matter / answer key) leaf.
+function leafTitle(leaf) {
+  if (leaf.role === 'title') return 'Title Page';
+  if (leaf.role === 'answerkey') return leaf.akIndex ? `Answer Key (${leaf.akIndex + 1})` : 'Answer Key';
+  return {
+    copyright: 'Copyright', belongsTo: 'This Book Belongs To', intro: 'Introduction',
+    about: 'About the Author', morebooks: 'More Books',
+  }[leaf.matterKind] || leaf.matterKind || 'Page';
+}
+
+function pagePlanRender(book, plan) {
+  if (!Array.isArray(plan) || !book || !Array.isArray(book.pages)) return { view: book, leaves: undefined };
+  const frontByKind = {};
+  (book.frontMatter || []).forEach((fm) => { frontByKind[fm.kind] = fm; });
+  const backByKind = {};
+  (book.backMatter || []).forEach((bm) => { backByKind[bm.kind] = bm; });
+
+  const leaves = [];
+  for (const e of plan) {
+    if (!e || typeof e !== 'object') continue;
+    const state = e.state && typeof e.state === 'object' ? e.state : null;
+    if (e.role === 'content') {
+      // A page inserted in the editor carries its own puzzle object; original
+      // pages reference the cached book by index (src).
+      const puzzle = (e.puzzle && typeof e.puzzle === 'object') ? e.puzzle : (book.pages[e.src] && book.pages[e.src].puzzle);
+      if (!puzzle) continue;
+      leaves.push({ role: 'content', puzzle, state, src: e.src });
+    } else if (e.role === 'blank') {
+      leaves.push({ role: 'content', puzzle: pf.generate({ type: 'bleedguard', label: '' }), state });
+    } else if (e.role === 'title') {
+      leaves.push({ role: 'title', state });
+    } else if (e.role === 'answerkey') {
+      leaves.push({ role: 'answerkey', akIndex: e.akIndex || 0, state });
+    } else if (e.role === 'frontmatter') {
+      const fm = frontByKind[e.matterKind]; if (!fm) continue;
+      leaves.push({ role: 'frontmatter', matter: fm, matterKind: fm.kind, state });
+    } else if (e.role === 'backmatter') {
+      const bm = backByKind[e.matterKind]; if (!bm) continue;
+      leaves.push({ role: 'backmatter', matter: bm, matterKind: bm.kind, state });
+    }
+  }
+  if (!leaves.length) return { view: book, leaves: undefined };
+
+  // Printed page numbers (content puzzles + answer key), by position.
+  let n = 0;
+  const pages = [];
+  for (const leaf of leaves) {
+    const numbered = (leaf.role === 'content' && leaf.puzzle.type !== 'bleedguard') || leaf.role === 'answerkey';
+    if (numbered) n += 1;
+    if (leaf.role === 'content') pages.push({ puzzle: leaf.puzzle, pageNumber: n, state: leaf.state });
+  }
+  const byType = {};
+  for (const p of pages) byType[p.puzzle.type] = (byType[p.puzzle.type] || 0) + 1;
+  const view = {
+    ...book,
+    pages,
+    puzzles: pages.map((p) => p.puzzle),
+    meta: {
+      ...book.meta,
+      pageCount: pages.length,
+      puzzleCount: pages.filter((p) => !pf.isActivityType(p.puzzle.type)).length,
+      byType,
+    },
+  };
+  return { view, leaves };
+}
+
+// Sanitize the editor's uploaded custom fonts before they reach the PDF doc.
+// Only data: URLs and pf-custom-<slug> family names survive; the font-face CSS
+// is re-derived from the slug in the engine, so nothing here is trusted verbatim.
+function sanitizeCustomFonts(fonts) {
+  if (!Array.isArray(fonts)) return undefined;
+  const out = [];
+  for (const f of fonts.slice(0, 24)) {
+    const family = String((f && f.family) || '');
+    const dataUrl = String((f && f.dataUrl) || '');
+    if (!/^pf-custom-[a-z0-9_-]+$/i.test(family)) continue;
+    if (!/^data:[a-z0-9/+.-]+;base64,[a-z0-9+/=]+$/i.test(dataUrl)) continue;
+    if (dataUrl.length > 2_000_000) continue; // ~1.5MB font, generous
+    out.push({ family, dataUrl });
+  }
+  return out;
+}
+
+// Resolve a request into the FINAL book + leaf order to render. Honors the
+// editor's pagePlan (hand arrangement + templates) so pre-flight checks,
+// royalty, and the export package all reflect exactly what will print.
+function resolveBook(body) {
+  let book = body.bookId && bookCache.get(body.bookId);
+  if (!book) book = pf.assembleBook(body.config || {});
+  // The editor sends the live master-page overlay separately so it applies even
+  // to a cached book (bookId) whose config predates the master.
+  if (body.master !== undefined) book.master = body.master;
+  book.customFonts = sanitizeCustomFonts(body.fonts);
+  let leaves;
+  if (Array.isArray(body.pagePlan)) { const r = pagePlanRender(book, body.pagePlan); book = r.view; leaves = r.leaves; }
+  else if (Array.isArray(body.pageState)) applyPageState(book, body.pageState);
+  return { book, leaves };
+}
+
+// Render `book` (with optional leaf order) to a temp PDF and return its bytes +
+// page count. Caller deletes nothing — the temp file is unlinked here.
+async function renderInterior(book, leaves) {
+  const outPath = path.join(os.tmpdir(), `pf-int-${crypto.randomUUID()}.pdf`);
+  try {
+    await pf.exportBookPdf(book, { outPath, leaves });
+    const buf = fs.readFileSync(outPath);
+    return { buf, pageCount: countPdfPages(buf) };
+  } finally {
+    fs.unlink(outPath, () => {});
+  }
+}
+
+// Open a book in the editor: assemble (or reuse), return per-page background
+// HTML + the usable-area dimensions the Fabric canvas maps onto.
+app.post('/api/book/editor', (req, res) => {
+  const body = req.body || {};
+  try {
+    let book = body.bookId && bookCache.get(body.bookId);
+    let bookId = body.bookId;
+    if (!book) {
+      book = pf.assembleBook(body.config || {});
+      bookId = cacheBook(book);
+    }
+    // Match the export layout (textScale + fontFamily), so what the editor
+    // splits and shows is what the PDF prints — otherwise large-print / a custom
+    // font can wrap text differently on export (e.g. a drawing-page title that
+    // fits on one line in the editor wraps to two on export and runs off).
+    const layout = pf.getLayout(book.trimSize, { audience: book.audience, textScale: book.fontScale, fontFamily: book.fontFamily });
+    // The book's decorative page frame is applied at render/export time, not
+    // baked into the split pieces — so seed it onto each eligible page's state
+    // so the editor draws the same border the Book Builder preview and PDF show.
+    // Match the exporter: the frame goes on real puzzle pages, never on activity
+    // (coloring/drawing) pages or front/back matter.
+    const bookBorder = book.border && book.border !== 'none' ? book.border : null;
+    const withBorder = (state, wants) => {
+      if (!bookBorder || !wants) return state || null;
+      const s = { ...(state || {}) };
+      if (s.border === undefined) s.border = bookBorder;
+      if (s.borderColor === undefined && book.borderColor) s.borderColor = book.borderColor;
+      return s;
+    };
+    // Every physical page (title, front matter, puzzles, answer key, back
+    // matter) as an editable, splittable leaf — so the editor shows the whole
+    // book, not only the puzzles.
+    const pages = pf.defaultLeaves(book).map((leaf, index) => {
+      let split, type, title, activity, src = null;
+      if (leaf.role === 'content') {
+        split = pf.splitPuzzle(leaf.puzzle, layout);
+        type = leaf.puzzle.type;
+        title = leaf.puzzle.title || leaf.puzzle.type;
+        activity = pf.isActivityType(leaf.puzzle.type);
+        src = leaf.src;
+      } else {
+        split = pf.splitHtml(pf.renderMatterDoc(book, layout, leaf));
+        type = leaf.role === 'title' ? 'title' : leaf.role === 'answerkey' ? 'answerkey' : leaf.matterKind;
+        title = leafTitle(leaf);
+        activity = true; // matter pages carry no puzzle to reroll
+      }
+      return {
+        index, role: leaf.role, matterKind: leaf.matterKind || null, src,
+        akIndex: leaf.akIndex != null ? leaf.akIndex : null,
+        type, title, activity,
+        style: split.style, components: split.components,
+        state: withBorder(leaf.state, leaf.role === 'content' && !activity),
+      };
+    });
+    res.json({
+      bookId,
+      seed: book.seed,
+      title: book.title,
+      dims: {
+        usableWidth: layout.usableWidth,
+        usableHeight: layout.usableHeight,
+        widthIn: layout.widthIn,
+        heightIn: layout.heightIn,
+      },
+      pages,
+    });
+  } catch (err) {
+    res.status(err.status || 400).json({ error: err.message });
+  }
+});
+
+// Generate fresh puzzle page(s) to insert into the open book, using the book's
+// own settings (theme, audience, trim, tier/difficulty ladder). Returns each as
+// an editor page (style + components) PLUS the raw puzzle object, so the editor
+// carries it in the page plan and it survives export and recipe save/reload.
+app.post('/api/book/insert-puzzle', (req, res) => {
+  const body = req.body || {};
+  try {
+    const type = String(body.type || '').trim();
+    if (!type) return res.status(400).json({ error: 'Pick a puzzle type.' });
+    const count = Math.max(1, Math.min(50, Number(body.count) || 1));
+    const difficulty = Math.max(1, Math.min(4, Number(body.difficulty) || 1));
+    const theme = String(body.theme || '').trim();
+    const audience = body.audience === 'adult' ? 'adult' : (body.audience === 'kids' ? 'kids' : undefined);
+    const style = String(body.style || '').trim();
+    // Inherit every setting from the open book, then override the puzzle list.
+    // A per-insert theme/audience/style (if any) overrides the book's default.
+    const base = { ...(body.config || {}) };
+    delete base.seed; delete base.pageState;
+    const spec = { type, count, difficulty, ...(theme ? { theme } : {}), ...(style ? { style } : {}) };
+    const cfg = { ...base, titlePage: false, answerKey: false, puzzles: [spec], ...(audience ? { audience } : {}) };
+    const gen = pf.assembleBook(cfg);
+    const layout = pf.getLayout(gen.trimSize, { audience: gen.audience, textScale: gen.fontScale, fontFamily: gen.fontFamily });
+    // Carry the book's page frame onto real puzzle pages (not activity pages),
+    // so an inserted puzzle matches the rest of a bordered book.
+    const bookBorder = gen.border && gen.border !== 'none' ? gen.border : null;
+    const pages = (gen.pages || [])
+      .filter((pg) => pg.puzzle && pg.puzzle.type !== 'bleedguard')
+      .map((pg) => {
+        const split = pf.splitPuzzle(pg.puzzle, layout);
+        const activity = pf.isActivityType(pg.puzzle.type);
+        return {
+          role: 'content', type: pg.puzzle.type,
+          title: pg.puzzle.title || pg.puzzle.type,
+          activity,
+          style: split.style, components: split.components, puzzle: pg.puzzle,
+          state: (bookBorder && !activity)
+            ? { border: bookBorder, ...(gen.borderColor ? { borderColor: gen.borderColor } : {}) }
+            : null,
+        };
+      });
+    if (!pages.length) return res.status(400).json({ error: 'Could not generate that puzzle type.' });
+    res.json({ pages, dims: { usableWidth: layout.usableWidth, usableHeight: layout.usableHeight } });
+  } catch (err) {
+    res.status(err.status || 400).json({ error: err.message });
+  }
+});
+
+// Rebuild a generation config from an existing puzzle so it can be re-rolled.
+function configFromPuzzle(p) {
+  const c = { type: p.type, difficulty: p.difficulty, theme: p.theme || undefined };
+  const d = p.data || {};
+  if (Array.isArray(d.words)) c.words = d.words.map((w) => (typeof w === 'string' ? w : w.word)).filter(Boolean);
+  if (d.clues) c.clues = d.clues;
+  if (d.size) c.size = d.size;
+  return c;
+}
+
+// Reroll one puzzle page (new layout, same type/difficulty/words) with a fresh
+// seed. Decorations live in the editor client and are unaffected.
+app.post('/api/book/reroll', (req, res) => {
+  const body = req.body || {};
+  const book = body.bookId && bookCache.get(body.bookId);
+  if (!book) return res.status(404).json({ error: 'Open the book in the editor again.' });
+  const pg = book.pages[body.index];
+  if (!pg) return res.status(400).json({ error: 'Invalid page.' });
+  try {
+    const p = pg.puzzle;
+    if (pf.isActivityType(p.type)) return res.status(400).json({ error: 'Activity pages have no puzzle to reroll.' });
+    const seed = (Math.random() * 0xffffffff) >>> 0;
+    const np = pf.generate(configFromPuzzle(p), { seed });
+    const pi = book.puzzles.indexOf(p);
+    pg.puzzle = np;
+    if (pi >= 0) book.puzzles[pi] = np;
+    const layout = pf.getLayout(book.trimSize, { audience: book.audience, textScale: book.fontScale, fontFamily: book.fontFamily });
+    const split = pf.splitPuzzle(np, layout);
+    res.json({ index: body.index, type: np.type, title: np.title, style: split.style, components: split.components, seed });
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
+// Pre-flight publish checklist (logic checks). Renders the interior once to get
+// an accurate page count (the answer key paginates), then runs the checks.
+app.post('/api/book/checklist', async (req, res) => {
+  const body = req.body || {};
+  try {
+    const { book, leaves } = resolveBook(body);
+    const { pageCount } = await renderInterior(book, leaves);
+    const result = pf.runChecklist(book, { pageCount, specs: (body.config || {}).puzzles });
+    res.json({ ...result, pageCount });
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
+// --- Publish flow: proofread + package export ---
+
+// User-authored prose on the pages: template/matter text objects the user typed,
+// plus the book title/subtitle. Puzzle grids and clues are excluded — they're
+// generated and proofreading them just flags intentional puzzle words.
+function collectProse(book) {
+  const out = [];
+  const push = (page, text) => { const t = String(text || '').trim(); if (t.length > 1) out.push({ page, text: t }); };
+  if (book.title) push(1, book.title);
+  if (book.subtitle) push(1, book.subtitle);
+  (book.pages || []).forEach((pg, i) => {
+    const els = pg.state && pg.state.layout && pg.state.layout.elements;
+    if (Array.isArray(els)) els.forEach((e) => { if (e && e.kind === 'text') push(pg.pageNumber || i + 1, e.text); });
+  });
+  return out;
+}
+
+const PROOF_MODEL = process.env.PUZZLEFORGE_PROOF_MODEL || 'claude-opus-4-8';
+async function proofreadSnippets(snippets) {
+  const client = new Anthropic();
+  const numbered = snippets.map((s, i) => `[#${i + 1} · page ${s.page}]\n${s.text}`).join('\n\n');
+  const schema = {
+    type: 'object', additionalProperties: false,
+    properties: {
+      issues: {
+        type: 'array',
+        items: {
+          type: 'object', additionalProperties: false,
+          properties: {
+            page: { type: 'integer' },
+            severity: { type: 'string', enum: ['error', 'suggestion'] },
+            original: { type: 'string' },
+            fix: { type: 'string' },
+            note: { type: 'string' },
+          },
+          required: ['page', 'severity', 'original', 'fix', 'note'],
+        },
+      },
+    },
+    required: ['issues'],
+  };
+  const prompt = [
+    'You are proofreading the reader-facing text of a print puzzle/activity book.',
+    'Report only real problems: spelling, grammar, punctuation, and clarity. Do NOT rewrite for style,',
+    'do NOT flag intentional puzzle words, brand names, or proper nouns, and do NOT invent issues.',
+    'Severity "error" = objectively wrong (misspelling, agreement); "suggestion" = a clear readability improvement.',
+    'For each issue give the exact original phrase and a minimal corrected version. If everything is clean, return an empty list.',
+    '',
+    'Snippets (page numbers in brackets):',
+    numbered,
+  ].join('\n');
+
+  const stream = client.messages.stream({
+    model: PROOF_MODEL,
+    max_tokens: 4000,
+    messages: [{ role: 'user', content: prompt }],
+    output_config: { format: { type: 'json_schema', schema } },
+  });
+  const msg = await stream.finalMessage();
+  const text = (msg.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+  let raw; try { raw = JSON.parse(text); } catch (_) { return []; }
+  return Array.isArray(raw.issues) ? raw.issues.slice(0, 200) : [];
+}
+
+// Proofread the book's editable text (honors the editor's pagePlan).
+app.post('/api/book/proofread', async (req, res) => {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(400).json({ error: 'Proofreading needs an Anthropic API key. Set ANTHROPIC_API_KEY and restart the server.' });
+  }
+  try {
+    const { book } = resolveBook(req.body || {});
+    const snippets = collectProse(book);
+    if (!snippets.length) {
+      return res.json({ issues: [], checked: 0, note: 'No editable text to proofread yet. Add a title, intro, or copyright page (Insert → Page template), then run again.' });
+    }
+    const issues = await proofreadSnippets(snippets);
+    res.json({ issues, checked: snippets.length, model: PROOF_MODEL });
+  } catch (err) {
+    const e = err instanceof Anthropic.AuthenticationError ? 'The Anthropic API key was rejected. Check ANTHROPIC_API_KEY.' : err.message;
+    res.status(err.status || 502).json({ error: e });
+  }
+});
+
+// Thesaurus: synonyms for a selected word/short phrase, so the editor can offer
+// one-click replacements. Kept small — a single word/phrase in, a ranked list out.
+async function synonymsFor(word) {
+  const client = new Anthropic();
+  const schema = {
+    type: 'object', additionalProperties: false,
+    properties: {
+      synonyms: { type: 'array', items: { type: 'string' } },
+      note: { type: 'string' },
+    },
+    required: ['synonyms', 'note'],
+  };
+  const prompt = [
+    `Give up to 8 natural synonyms or close alternatives for the word or phrase: "${word}".`,
+    'Match its likely part of speech and register. Order best-first. Single words or short phrases only.',
+    'If it is a proper noun, number, or has no real synonyms, return an empty list and say why in "note" (else leave "note" empty).',
+  ].join('\n');
+  const stream = client.messages.stream({
+    model: PROOF_MODEL,
+    max_tokens: 500,
+    messages: [{ role: 'user', content: prompt }],
+    output_config: { format: { type: 'json_schema', schema } },
+  });
+  const msg = await stream.finalMessage();
+  const text = (msg.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+  let raw; try { raw = JSON.parse(text); } catch (_) { return { synonyms: [], note: '' }; }
+  return { synonyms: Array.isArray(raw.synonyms) ? raw.synonyms.slice(0, 8) : [], note: raw.note || '' };
+}
+
+app.post('/api/thesaurus', async (req, res) => {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(400).json({ error: 'The thesaurus needs an Anthropic API key. Set ANTHROPIC_API_KEY and restart the server.' });
+  }
+  const word = String((req.body && req.body.word) || '').trim();
+  if (!word) return res.status(400).json({ error: 'Select a text box (or type a word) to look up.' });
+  if (word.length > 80) return res.status(400).json({ error: 'That is too long for a thesaurus lookup — select a single word or short phrase.' });
+  try {
+    res.json(await synonymsFor(word));
+  } catch (err) {
+    const e = err instanceof Anthropic.AuthenticationError ? 'The Anthropic API key was rejected. Check ANTHROPIC_API_KEY.' : err.message;
+    res.status(err.status || 502).json({ error: e });
+  }
+});
+
+function renderChecklistText(chk, pageCount) {
+  const lines = [
+    'PuzzleForge — Pre-flight checklist',
+    '==================================',
+    '',
+    `Pages: ${pageCount}`,
+    `Blockers: ${chk.summary.blockers}   Warnings: ${chk.summary.warnings}   Passed: ${chk.summary.passes}`,
+    '',
+  ];
+  chk.items.forEach((it) => {
+    const tag = it.status === 'pass' ? 'PASS   ' : it.severity === 'blocker' ? 'BLOCKER' : 'WARN   ';
+    lines.push(`[${tag}] ${it.label}${it.message ? ` — ${it.message}` : ''}`);
+  });
+  return lines.join('\n') + '\n';
+}
+function renderProofreadText(issues) {
+  const lines = ['PuzzleForge — Proofread notes', '=============================', '', `${issues.length} item(s). AI-assisted — review each before accepting.`, ''];
+  issues.forEach((it, i) => {
+    lines.push(`${i + 1}. [page ${it.page || '?'}] (${it.severity || 'suggestion'})`);
+    lines.push(`   original: ${it.original || ''}`);
+    lines.push(`   fix:      ${it.fix || ''}`);
+    if (it.note) lines.push(`   note:     ${it.note}`);
+    lines.push('');
+  });
+  return lines.join('\n') + '\n';
+}
+
+function countPdfPages(pdfBuffer) {
+  const s = pdfBuffer.toString('latin1');
+  const pageObjs = (s.match(/\/Type\s*\/Page\b(?!s)/g) || []).length;
+  let maxCount = 0;
+  for (const m of s.matchAll(/\/Type\s*\/Pages\b[\s\S]*?\/Count\s+(\d+)/g)) {
+    maxCount = Math.max(maxCount, Number(m[1]));
+  }
+  return Math.max(pageObjs, maxCount) || pageObjs;
+}
+
+// Cover-image resolution lines for the build-info sheet (empty when no image).
+function coverImageLines(coverConfig) {
+  if (!coverConfig) return [];
+  let d;
+  try { d = pf.frontImageDpi(coverConfig); } catch (_) { d = null; }
+  if (!d) return [];
+  return [
+    `Cover image:      ${d.width} x ${d.height}px → ~${d.dpi} DPI on the front panel` +
+      (d.ok ? ' (OK)' : `  ⚠ BELOW ${d.minDpi} DPI — use a larger image`),
+  ];
+}
+
+function buildInfoSheet(config, book, pageCount, paper, dims, meta, coverConfig) {
+  const md = pf.normalizeMetadata(meta || {});
+  const colorPaper = paper === 'cream' ? 'bw' : 'bw'; // interiors here are B&W
+  const est = pf.royaltyEstimate({ pageCount, paper: colorPaper, listPrice: md.listPrice });
+  const disc = pf.aiDisclosure(md);
+  const usd = (n) => (n == null ? '—' : `$${Number(n).toFixed(2)}`);
+  const slot = (arr, n) =>
+    Array.from({ length: n }, (_, i) => `  ${i + 1}. ${arr[i] || ''}`).join('\n');
+
+  const lines = [
+    'PuzzleForge — KDP Build Info',
+    '============================',
+    '',
+    `Title:            ${config.title || ''}`,
+    config.subtitle ? `Subtitle:         ${config.subtitle}` : null,
+    `Author:           ${config.author || ''}`,
+    md.seriesName ? `Series:           ${md.seriesName}${md.seriesNumber ? ` (book ${md.seriesNumber})` : ''}` : null,
+    md.readingAge ? `Reading age:      ${md.readingAge}` : null,
+    `Language:         ${md.language}`,
+    '',
+    `Trim size:        ${dims.trimWidthIn} x ${dims.trimHeightIn} in`,
+    `Interior pages:   ${pageCount}`,
+    `Paper:            ${paper}`,
+    `Spine width:      ${dims.spineIn} in`,
+    `Full cover size:  ${dims.fullWidthIn} x ${dims.fullHeightIn} in (includes 0.125" bleed)`,
+    `Spine text:       ${dims.spineTextAllowed ? 'printed (book is long enough)' : 'hidden (KDP needs >= 79 pages)'}`,
+    ...coverImageLines(coverConfig),
+    '',
+    'Description / blurb',
+    '-------------------',
+    md.description || '(none entered)',
+    '',
+    'Keywords (7 slots — fill all for discoverability)',
+    '-------------------------------------------------',
+    slot(md.keywords, 7),
+    '',
+    'Categories (3 slots)',
+    '--------------------',
+    slot(md.categories, 3),
+    '',
+    'Royalty estimate (US, 60%, B&W) — confirm rates on KDP',
+    '------------------------------------------------------',
+    `Printing cost:    ${usd(est.printCost)}  (rates as of ${est.ratesUpdated})`,
+    `Breakeven price:  ${usd(est.breakeven)}  (minimum list price for any royalty)`,
+    `Suggested range:  ${usd(est.suggestedLow)} – ${usd(est.suggestedHigh)}`,
+    md.listPrice != null ? `At list ${usd(est.listPrice)}: royalty ${usd(est.royalty)} / sale${est.belowMinimum ? '  ⚠ BELOW BREAKEVEN' : ''}` : 'List price:       (not set)',
+    '',
+    'AI disclosure (KDP upload form — readers never see this)',
+    '-------------------------------------------------------',
+    `Used AI:          ${disc.usedAI ? 'Yes' : 'No'}`,
+    `Content type(s):  ${disc.contentTypes.length ? disc.contentTypes.join('; ') : 'None'}`,
+    `AI tool(s):       ${disc.tools.length ? disc.tools.join('; ') : 'None'}`,
+    'Note: puzzle grids and answer keys are algorithmic — not AI — and are not disclosed.',
+    '',
+    'Files in this bundle',
+    '--------------------',
+    'interior.pdf  — upload as the book interior / manuscript',
+    'cover.pdf     — upload as the full-wrap paperback cover',
+    '',
+    'When setting up the KDP paperback, match these exactly:',
+    `  • Trim size: ${dims.trimWidthIn} x ${dims.trimHeightIn} in`,
+    `  • Paper type: ${paper}`,
+    '  • Bleed: Yes (the cover includes 0.125" bleed)',
+  ];
+  if (pageCount < 24) {
+    lines.push('', `WARNING: KDP requires at least 24 pages — this book has ${pageCount}. Add more content.`);
+  }
+  if (pageCount % 2 !== 0) {
+    lines.push('', `NOTE: page count is odd (${pageCount}) — add one blank page so KDP doesn't pad it unpredictably.`);
+  }
+  return lines.filter((l) => l !== null).join('\n') + '\n';
+}
+
+// Export the finished book as one KDP upload package: interior PDF (honoring the
+// editor's arrangement), a simple auto-generated full-wrap cover PDF, build-info
+// sheet, pre-flight checklist, and (if supplied) proofread notes — zipped.
+app.post('/api/book/package', async (req, res) => {
+  const body = req.body || {};
+  const coverIn = body.cover || {};
+  const metadata = body.metadata || {};
+  try {
+    const { book, leaves } = resolveBook(body);
+    const { buf: interior, pageCount } = await renderInterior(book, leaves);
+    const paper = metadata.paper === 'cream' || coverIn.paper === 'cream' ? 'cream' : 'white';
+
+    const coverConfig = {
+      trimSize: book.trimSize, pageCount, paper,
+      title: book.title, subtitle: book.subtitle, author: book.author,
+      front: { bgColor: coverIn.bgColor, textColor: coverIn.textColor, titlePosition: coverIn.titlePosition || 'center', image: coverIn.image || null },
+      back: { bgColor: coverIn.backColor || coverIn.bgColor, textColor: coverIn.textColor, blurb: coverIn.blurb || metadata.description || null },
+      spine: { bgColor: coverIn.bgColor, textColor: coverIn.textColor },
+    };
+    const coverPath = path.join(os.tmpdir(), `pf-cov-${crypto.randomUUID()}.pdf`);
+    let cover;
+    try { await pf.exportCoverPdf(coverConfig, { outPath: coverPath }); cover = fs.readFileSync(coverPath); } finally { fs.unlink(coverPath, () => {}); }
+
+    const dims = pf.coverDimensions(book.trimSize, pageCount, paper);
+    const info = buildInfoSheet({ title: book.title, subtitle: book.subtitle, author: book.author }, book, pageCount, paper, dims, metadata, coverConfig);
+    const chkReport = renderChecklistText(pf.runChecklist(book, { pageCount }), pageCount);
+
+    const base = (book.title || 'book').replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${base}-kdp-package.zip"`);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    archive.on('error', (err) => { if (!res.headersSent) res.status(500).json({ error: err.message }); });
+    archive.pipe(res);
+    archive.append(interior, { name: 'interior.pdf' });
+    archive.append(cover, { name: 'cover.pdf' });
+    archive.append(info, { name: 'build-info.txt' });
+    archive.append(chkReport, { name: 'preflight-checklist.txt' });
+    if (Array.isArray(body.proofreadIssues) && body.proofreadIssues.length) {
+      archive.append(renderProofreadText(body.proofreadIssues), { name: 'proofread-notes.txt' });
+    }
+    await archive.finalize();
+  } catch (err) {
+    if (!res.headersSent) res.status(err.status || 500).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 4100;
+if (require.main === module) {
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`PuzzleForge Publisher running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = { app };


### PR DESCRIPTION
## Summary
- Add a new top-level `publisher/` app: a trimmed, Electron-wrapped copy of the Page Editor from `puzzleforge-web`, shipped as its own standalone desktop app with nothing else attached — no Puzzle Maker, Book Builder, Worksheets, Themes, Image Tools, Cover Builder, AI Art, or team workspace.
- `publisher/server.js` keeps only the endpoints the editor itself calls: assemble/open a book, insert/reroll a puzzle page, PDF export, pre-flight checklist, AI proofread + thesaurus, and KDP package export, plus the shared renderer routes (`element-html.js`, `decor.js`, `qrcode-generator.js`). Every helper function was checked against its call sites before being kept or dropped.
- `publisher/public/editor.html` has the nav links to Book Builder/My Books, the AI Art button, and the Cover Builder button/handoff removed. Their `editor.js` listeners were already null-guarded, so no JS changes were needed there.
- `publisher/electron/main.js` boots the trimmed server in-process and opens straight to `editor.html` in a native window — there is nowhere else in this app to navigate to.
- `publisher/public/starter-recipe.json` — a bundled example book so a first-time user has something to load via "Open recipe".
- `publisher/package.json` depends on the sibling `engine/` directory via the same `puzzleforge-engine: file:..` dependency `puzzleforge-web` uses, with the same electron-builder excludes (from #12) to prevent that symlink from recursively bundling itself — now also excluding `publisher/` from within the engine's own symlinked tree.

## Test plan
- [x] `npm install` in `publisher/` and at the repo root succeeds.
- [x] `node --check server.js` / `node --check electron/main.js` — syntax OK.
- [x] Launched the actual Electron app end-to-end under Xvfb (`--no-sandbox`, no display in this sandbox) and exercised the real API against the bundled starter recipe:
  - [x] `/api/book/editor` — assembled a 9-page book.
  - [x] `/api/book/insert-puzzle` — inserted a new puzzle page.
  - [x] `/api/book/reroll` — rerolled an existing puzzle page.
  - [x] `/api/book/checklist` — ran the pre-flight checklist.
  - [x] `/api/book/pdf` — exported a real 8-page interior PDF through headless Chromium.
  - [x] `/api/book/package` — exported a full KDP package zip (interior + auto-generated cover + build-info + checklist).
  - [x] Confirmed the AI endpoints (`/api/thesaurus`, proofread) fail with a clear "set ANTHROPIC_API_KEY" message rather than crashing, and the now-absent `/api/workspace` correctly 404s without breaking `identity.js`/`library.js` (both already degrade gracefully by design).
- [ ] Not verified: `npm run dist:win` (Windows installer build) for this app specifically — see the sibling PR #12 for the general cross-build findings (self-referential bundling fix, and the open question about bundling the engine's own runtime deps like `puppeteer-core` for a packaged app). The same considerations apply here.
- [ ] No in-app way to create a brand-new book from scratch (that flow lived in Book Builder, which is intentionally dropped) — you get to a book via the bundled starter recipe or a hand-authored/obtained recipe `.json`. Flagging as a known gap, not something silently worked around.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WxeZub2H5TW6FnQt6W3P5C)_